### PR TITLE
Replace equivalent fmt.Sprintf calls with strconv.Itoa

### DIFF
--- a/enterprise/internal/batches/sources/sources_test.go
+++ b/enterprise/internal/batches/sources/sources_test.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -73,7 +74,7 @@ func TestExtractCloneURL(t *testing.T) {
 			}
 
 			for idx := range tc.configs {
-				repo.Sources[fmt.Sprintf("%d", idx)] = &types.SourceInfo{
+				repo.Sources[strconv.Itoa(idx)] = &types.SourceInfo{
 					ID: fmt.Sprintf("::%d", idx), // see SourceInfo.ExternalServiceID
 				}
 			}

--- a/internal/cmd/tracking-issue/issue_loader.go
+++ b/internal/cmd/tracking-issue/issue_loader.go
@@ -207,7 +207,7 @@ func (l *IssueLoader) performRequest(ctx context.Context, cli *graphql.Client, r
 // This is used to later construct a GraphQL request with a subset of these queries.
 func makeFragmentArgs(n int) (fragments []string, args [][]string) {
 	for i := 0; i < n; i++ {
-		fragments = append(fragments, makeSearchQuery(fmt.Sprintf("%d", i)))
+		fragments = append(fragments, makeSearchQuery(strconv.Itoa(i)))
 
 		args = append(args, []string{
 			fmt.Sprintf("$query%d: String!", i),

--- a/internal/workerutil/dbworker/store/store_test.go
+++ b/internal/workerutil/dbworker/store/store_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"testing"
 	"time"
 
@@ -393,7 +394,7 @@ func TestStoreAddExecutionLogEntry(t *testing.T) {
 	numEntries := 5
 
 	for i := 0; i < numEntries; i++ {
-		command := []string{"ls", "-a", fmt.Sprintf("%d", i+1)}
+		command := []string{"ls", "-a", strconv.Itoa(i + 1)}
 		payload := fmt.Sprintf("<load payload %d>", i+1)
 
 		entry := workerutil.ExecutionLogEntry{
@@ -426,7 +427,7 @@ func TestStoreAddExecutionLogEntry(t *testing.T) {
 		}
 
 		expected := workerutil.ExecutionLogEntry{
-			Command: []string{"ls", "-a", fmt.Sprintf("%d", i+1)},
+			Command: []string{"ls", "-a", strconv.Itoa(i + 1)},
 			Out:     fmt.Sprintf("<load payload %d>", i+1),
 		}
 		if diff := cmp.Diff(expected, entry); diff != "" {
@@ -462,7 +463,7 @@ func TestStoreUpdateExecutionLogEntry(t *testing.T) {
 
 	numEntries := 5
 	for i := 0; i < numEntries; i++ {
-		command := []string{"ls", "-a", fmt.Sprintf("%d", i+1)}
+		command := []string{"ls", "-a", strconv.Itoa(i + 1)}
 		payload := fmt.Sprintf("<load payload %d>", i+1)
 
 		entry := workerutil.ExecutionLogEntry{
@@ -500,7 +501,7 @@ func TestStoreUpdateExecutionLogEntry(t *testing.T) {
 		}
 
 		expected := workerutil.ExecutionLogEntry{
-			Command: []string{"ls", "-a", fmt.Sprintf("%d", i+1)},
+			Command: []string{"ls", "-a", strconv.Itoa(i + 1)},
 			Out:     fmt.Sprintf("<load payload %d>\n<load payload %d again, nobody was at home>", i+1, i+1),
 		}
 		if diff := cmp.Diff(expected, entry); diff != "" {

--- a/lib/codeintel/tools/lsif-index-tester/range_differ.go
+++ b/lib/codeintel/tools/lsif-index-tester/range_differ.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/cockroachdb/errors"
@@ -65,7 +66,7 @@ func DrawLocations(contents string, expected, actual Location, context int) (str
 
 		text := header(expected) + "\n"
 
-		prefixWidth := len(fmt.Sprintf("%d", line+1+context))
+		prefixWidth := len(strconv.Itoa(line + 1 + context))
 
 		for offset := context; offset > 0; offset-- {
 			newLine := line - offset


### PR DESCRIPTION
This batch change replaces `fmt.Sprintf("%d", integer)` calls with semantically equivalent `strconv.Itoa` calls

[_Created by Sourcegraph batch change `malo/fmt-sprintf-toitoa`._](https://demo.sourcegraph.com/users/malo/batch-changes/fmt-sprintf-toitoa)