### PR TITLE
Go 1.18: rewrite `interface{}` to `any`

### DIFF
--- a/cmd/frontend/auth/user_test.go
+++ b/cmd/frontend/auth/user_test.go
@@ -399,8 +399,8 @@ func TestGetAndSaveUser(t *testing.T) {
 						userID, safeErr, err := GetAndSaveUser(ctx, db, op)
 						for _, v := range []struct {
 							label string
-							got   interface{}
-							want  interface{}
+							got   any
+							want  any
 						}{
 							{"userID", userID, c.expUserID},
 							{"safeErr", safeErr, c.expSafeErr},

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -214,7 +214,7 @@ func (s *repos) GetInventory(ctx context.Context, repo *types.Repo, commitID api
 		return Mocks.Repos.GetInventory(ctx, repo, commitID)
 	}
 
-	ctx, done := trace(ctx, "Repos", "GetInventory", map[string]interface{}{"repo": repo.Name, "commitID": commitID}, &err)
+	ctx, done := trace(ctx, "Repos", "GetInventory", map[string]any{"repo": repo.Name, "commitID": commitID}, &err)
 	defer done()
 
 	// Cap GetInventory operation to some reasonable time.

--- a/cmd/frontend/backend/repos_vcs.go
+++ b/cmd/frontend/backend/repos_vcs.go
@@ -24,7 +24,7 @@ func (s *repos) ResolveRev(ctx context.Context, repo *types.Repo, rev string) (c
 		return Mocks.Repos.ResolveRev(ctx, repo, rev)
 	}
 
-	ctx, done := trace(ctx, "Repos", "ResolveRev", map[string]interface{}{"repo": repo.Name, "rev": rev}, &err)
+	ctx, done := trace(ctx, "Repos", "ResolveRev", map[string]any{"repo": repo.Name, "rev": rev}, &err)
 	defer done()
 
 	return git.ResolveRevision(ctx, repo.Name, rev, git.ResolveRevisionOptions{})
@@ -35,7 +35,7 @@ func (s *repos) GetCommit(ctx context.Context, repo *types.Repo, commitID api.Co
 		return Mocks.Repos.GetCommit(ctx, repo, commitID)
 	}
 
-	ctx, done := trace(ctx, "Repos", "GetCommit", map[string]interface{}{"repo": repo.Name, "commitID": commitID}, &err)
+	ctx, done := trace(ctx, "Repos", "GetCommit", map[string]any{"repo": repo.Name, "commitID": commitID}, &err)
 	defer done()
 
 	log15.Debug("svc.local.repos.GetCommit", "repo", repo.Name, "commitID", commitID)

--- a/cmd/frontend/backend/trace.go
+++ b/cmd/frontend/backend/trace.go
@@ -27,7 +27,7 @@ var requestGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Help: "Current number of requests running for a method.",
 }, []string{"method"})
 
-func trace(ctx context.Context, server, method string, arg interface{}, err *error) (context.Context, func()) {
+func trace(ctx context.Context, server, method string, arg any, err *error) (context.Context, func()) {
 	requestGauge.WithLabelValues(server + "." + method).Inc()
 
 	span, ctx := ot.StartSpanFromContext(ctx, server+"."+method)

--- a/cmd/frontend/graphqlbackend/access_tokens_test.go
+++ b/cmd/frontend/graphqlbackend/access_tokens_test.go
@@ -164,7 +164,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 				ExpectedResult: `null`,
 				ExpectedErrors: []*gqlerrors.QueryError{
 					{
-						Path:          []interface{}{"createAccessToken"},
+						Path:          []any{"createAccessToken"},
 						Message:       "Must be authenticated as user with id 1",
 						ResolverError: &backend.InsufficientAuthorizationError{Message: fmt.Sprintf("Must be authenticated as user with id %d", 1)},
 					},

--- a/cmd/frontend/graphqlbackend/bigint.go
+++ b/cmd/frontend/graphqlbackend/bigint.go
@@ -27,7 +27,7 @@ func (v BigInt) MarshalJSON() ([]byte, error) {
 	return json.Marshal(strconv.FormatInt(v.Int, 10))
 }
 
-func (v *BigInt) UnmarshalGraphQL(input interface{}) error {
+func (v *BigInt) UnmarshalGraphQL(input any) error {
 	s, ok := input.(string)
 	if !ok {
 		return errors.Errorf("invalid GraphQL BigInt scalar value input (got %T, expected string)", input)

--- a/cmd/frontend/graphqlbackend/datetime.go
+++ b/cmd/frontend/graphqlbackend/datetime.go
@@ -27,7 +27,7 @@ func (v DateTime) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.Time.Format(time.RFC3339))
 }
 
-func (v *DateTime) UnmarshalGraphQL(input interface{}) error {
+func (v *DateTime) UnmarshalGraphQL(input any) error {
 	s, ok := input.(string)
 	if !ok {
 		return errors.Errorf("invalid GraphQL DateTime scalar value input (got %T, expected string)", input)

--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -50,7 +50,7 @@ var builtinExtensions = map[string]bool{
 	"sourcegraph/vhdl":       true,
 }
 
-func defaultSettings(db dbutil.DB) map[string]interface{} {
+func defaultSettings(db dbutil.DB) map[string]any {
 	extensionIDs := []string{}
 	for id := range builtinExtensions {
 		extensionIDs = append(extensionIDs, id)
@@ -61,8 +61,8 @@ func defaultSettings(db dbutil.DB) map[string]interface{} {
 		extensions[id] = true
 	}
 
-	return map[string]interface{}{
-		"experimentalFeatures": map[string]interface{}{},
+	return map[string]any{
+		"experimentalFeatures": map[string]any{},
 		"extensions":           extensions,
 	}
 }

--- a/cmd/frontend/graphqlbackend/extension_registry.go
+++ b/cmd/frontend/graphqlbackend/extension_registry.go
@@ -98,7 +98,7 @@ type ExtensionRegistryMutationResult interface {
 
 // NodeToRegistryExtension is called to convert GraphQL node values to values of type
 // RegistryExtension. It is assigned at init time.
-var NodeToRegistryExtension func(interface{}) (RegistryExtension, bool)
+var NodeToRegistryExtension func(any) (RegistryExtension, bool)
 
 // RegistryExtensionByID is called to look up values of GraphQL type RegistryExtension. It is
 // assigned at init time.

--- a/cmd/frontend/graphqlbackend/external_services_test.go
+++ b/cmd/frontend/graphqlbackend/external_services_test.go
@@ -722,7 +722,7 @@ func TestExternalServices(t *testing.T) {
 		`,
 			ExpectedErrors: []*gqlerrors.QueryError{
 				{
-					Path:          []interface{}{"externalServices"},
+					Path:          []any{"externalServices"},
 					Message:       errNoAccessExternalService.Error(),
 					ResolverError: errNoAccessExternalService,
 				},

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -46,49 +46,49 @@ func TestGitCommitResolver(t *testing.T) {
 
 		for _, tc := range []struct {
 			name string
-			want interface{}
-			have func(*GitCommitResolver) (interface{}, error)
+			want any
+			have func(*GitCommitResolver) (any, error)
 		}{{
 			name: "author",
 			want: toSignatureResolver(db, &commit.Author, true),
-			have: func(r *GitCommitResolver) (interface{}, error) {
+			have: func(r *GitCommitResolver) (any, error) {
 				return r.Author(ctx)
 			},
 		}, {
 			name: "committer",
 			want: toSignatureResolver(db, commit.Committer, true),
-			have: func(r *GitCommitResolver) (interface{}, error) {
+			have: func(r *GitCommitResolver) (any, error) {
 				return r.Committer(ctx)
 			},
 		}, {
 			name: "message",
 			want: string(commit.Message),
-			have: func(r *GitCommitResolver) (interface{}, error) {
+			have: func(r *GitCommitResolver) (any, error) {
 				return r.Message(ctx)
 			},
 		}, {
 			name: "subject",
 			want: "subject: Changes things",
-			have: func(r *GitCommitResolver) (interface{}, error) {
+			have: func(r *GitCommitResolver) (any, error) {
 				return r.Subject(ctx)
 			},
 		}, {
 			name: "body",
 			want: "Body of changes",
-			have: func(r *GitCommitResolver) (interface{}, error) {
+			have: func(r *GitCommitResolver) (any, error) {
 				s, err := r.Body(ctx)
 				return *s, err
 			},
 		}, {
 			name: "url",
 			want: "/bob-repo/-/commit/c1",
-			have: func(r *GitCommitResolver) (interface{}, error) {
+			have: func(r *GitCommitResolver) (any, error) {
 				return r.URL(), nil
 			},
 		}, {
 			name: "canonical-url",
 			want: "/bob-repo/-/commit/c1",
-			have: func(r *GitCommitResolver) (interface{}, error) {
+			have: func(r *GitCommitResolver) (any, error) {
 				return r.CanonicalURL(), nil
 			},
 		}} {

--- a/cmd/frontend/graphqlbackend/git_object.go
+++ b/cmd/frontend/graphqlbackend/git_object.go
@@ -41,7 +41,7 @@ func (GitObjectID) ImplementsGraphQLType(name string) bool {
 	return name == "GitObjectID"
 }
 
-func (id *GitObjectID) UnmarshalGraphQL(input interface{}) error {
+func (id *GitObjectID) UnmarshalGraphQL(input any) error {
 	if input, ok := input.(string); ok && git.IsAbsoluteRevision(input) {
 		*id = GitObjectID(input)
 		return nil

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -255,4 +255,4 @@ func (f fileInfo) Mode() os.FileMode {
 	return 0
 }
 func (f fileInfo) ModTime() time.Time { return time.Now() }
-func (f fileInfo) Sys() interface{}   { return interface{}(nil) }
+func (f fileInfo) Sys() any           { return any(nil) }

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -50,7 +50,7 @@ type prometheusTracer struct {
 	trace.OpenTracingTracer
 }
 
-func (t *prometheusTracer) TraceQuery(ctx context.Context, queryString string, operationName string, variables map[string]interface{}, varTypes map[string]*introspection.Type) (context.Context, trace.TraceQueryFinishFunc) {
+func (t *prometheusTracer) TraceQuery(ctx context.Context, queryString string, operationName string, variables map[string]any, varTypes map[string]*introspection.Type) (context.Context, trace.TraceQueryFinishFunc) {
 	start := time.Now()
 	var finish trace.TraceQueryFinishFunc
 	if ot.ShouldTrace(ctx) {
@@ -121,7 +121,7 @@ VARIABLES
 	}
 }
 
-func (prometheusTracer) TraceField(ctx context.Context, label, typeName, fieldName string, trivial bool, args map[string]interface{}) (context.Context, trace.TraceFieldFinishFunc) {
+func (prometheusTracer) TraceField(ctx context.Context, label, typeName, fieldName string, trivial bool, args map[string]any) (context.Context, trace.TraceFieldFinishFunc) {
 	start := time.Now()
 	return ctx, func(err *gqlerrors.QueryError) {
 		isErrStr := strconv.FormatBool(err != nil)
@@ -312,8 +312,7 @@ var blocklistedPrometheusTypeNames = map[string]struct{}{
 // not worth tracking. You can find a complete list of the ones Prometheus is
 // currently tracking via:
 //
-// 	sum by (type)(src_graphql_field_seconds_count)
-//
+//	sum by (type)(src_graphql_field_seconds_count)
 func prometheusTypeName(typeName string) string {
 	if _, ok := blocklistedPrometheusTypeNames[typeName]; ok {
 		return "other"

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -78,7 +78,7 @@ func TestResolverTo(t *testing.T) {
 	// run. The To* resolvers are stored in a map in our graphql
 	// implementation => the order we call them is non deterministic =>
 	// codecov coverage reports are noisy.
-	resolvers := []interface{}{
+	resolvers := []any{
 		&FileMatchResolver{db: db},
 		&GitTreeEntryResolver{db: db},
 		&NamespaceResolver{},
@@ -301,7 +301,7 @@ func TestAffiliatedRepositories(t *testing.T) {
 			ExpectedResult: `null`,
 			ExpectedErrors: []*gqlerrors.QueryError{
 				{
-					Path:          []interface{}{"affiliatedRepositories"},
+					Path:          []any{"affiliatedRepositories"},
 					Message:       "Must be authenticated as user with id 1",
 					ResolverError: &backend.InsufficientAuthorizationError{Message: fmt.Sprintf("Must be authenticated as user with id %d", 1)},
 				},
@@ -410,7 +410,7 @@ func TestAffiliatedRepositories(t *testing.T) {
 			ExpectedResult: `null`,
 			ExpectedErrors: []*gqlerrors.QueryError{
 				{
-					Path:          []interface{}{"affiliatedRepositories", "nodes"},
+					Path:          []any{"affiliatedRepositories", "nodes"},
 					Message:       "failed to fetch from any code host",
 					ResolverError: errors.New("failed to fetch from any code host"),
 				},

--- a/cmd/frontend/graphqlbackend/json.go
+++ b/cmd/frontend/graphqlbackend/json.go
@@ -8,13 +8,13 @@ import (
 
 // JSONValue implements the JSONValue scalar type. In GraphQL queries, it is represented the JSON
 // representation of its Go value.
-type JSONValue struct{ Value interface{} }
+type JSONValue struct{ Value any }
 
 func (JSONValue) ImplementsGraphQLType(name string) bool {
 	return name == "JSONValue"
 }
 
-func (v *JSONValue) UnmarshalGraphQL(input interface{}) error {
+func (v *JSONValue) UnmarshalGraphQL(input any) error {
 	*v = JSONValue{Value: input}
 	return nil
 }
@@ -34,7 +34,7 @@ func (JSONCString) ImplementsGraphQLType(name string) bool {
 	return name == "JSONCString"
 }
 
-func (j *JSONCString) UnmarshalGraphQL(input interface{}) error {
+func (j *JSONCString) UnmarshalGraphQL(input any) error {
 	s, ok := input.(string)
 	if !ok {
 		return errors.Errorf("invalid GraphQL JSONCString scalar value input (got %T, expected string)", input)

--- a/cmd/frontend/graphqlbackend/namespaces_test.go
+++ b/cmd/frontend/graphqlbackend/namespaces_test.go
@@ -100,7 +100,7 @@ func TestNamespace(t *testing.T) {
 			`,
 				ExpectedErrors: []*gqlerrors.QueryError{
 					{
-						Path:          []interface{}{"namespace"},
+						Path:          []any{"namespace"},
 						Message:       wantErr.Error(),
 						ResolverError: wantErr,
 					},

--- a/cmd/frontend/graphqlbackend/parse_search_query.go
+++ b/cmd/frontend/graphqlbackend/parse_search_query.go
@@ -7,10 +7,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 )
 
-func toJSON(node query.Node) interface{} {
+func toJSON(node query.Node) any {
 	switch n := node.(type) {
 	case query.Operator:
-		var jsons []interface{}
+		var jsons []any
 		for _, o := range n.Operands {
 			jsons = append(jsons, toJSON(o))
 		}
@@ -18,13 +18,13 @@ func toJSON(node query.Node) interface{} {
 		switch n.Kind {
 		case query.And:
 			return struct {
-				And []interface{} `json:"and"`
+				And []any `json:"and"`
 			}{
 				And: jsons,
 			}
 		case query.Or:
 			return struct {
-				Or []interface{} `json:"or"`
+				Or []any `json:"or"`
 			}{
 				Or: jsons,
 			}
@@ -33,7 +33,7 @@ func toJSON(node query.Node) interface{} {
 			// the original query expresses something that is not
 			// supported. We just return the parse tree anyway.
 			return struct {
-				Concat []interface{} `json:"concat"`
+				Concat []any `json:"concat"`
 			}{
 				Concat: jsons,
 			}
@@ -100,7 +100,7 @@ func (r *schemaResolver) ParseSearchQuery(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	var jsons []interface{}
+	var jsons []any
 	for _, node := range plan.ToParseTree() {
 		jsons = append(jsons, toJSON(node))
 	}

--- a/cmd/frontend/graphqlbackend/rate_limit.go
+++ b/cmd/frontend/graphqlbackend/rate_limit.go
@@ -30,7 +30,7 @@ type QueryCost struct {
 // EstimateQueryCost estimates the cost of the query before it is actually
 // executed. It is a worst cast estimate of the number of fields expected to be
 // returned by the query and handles nested queries a well as fragments.
-func EstimateQueryCost(query string, variables map[string]interface{}) (totalCost *QueryCost, err error) {
+func EstimateQueryCost(query string, variables map[string]any) (totalCost *QueryCost, err error) {
 	// NOTE: When we encounter errors in our visit funcs we return
 	// visitor.ActionBreak to stop walking the tree and set the top level err
 	// variable so that it is returned
@@ -47,7 +47,7 @@ func EstimateQueryCost(query string, variables map[string]interface{}) (totalCos
 		}
 	}()
 	if variables == nil {
-		variables = make(map[string]interface{})
+		variables = make(map[string]any)
 	}
 
 	doc, err := parser.Parse(parser.ParseParams{
@@ -140,7 +140,7 @@ func EstimateQueryCost(query string, variables map[string]interface{}) (totalCos
 	return totalCost, nil
 }
 
-func calcNodeCost(def ast.Node, fragmentCosts map[string]int, variables map[string]interface{}) (*QueryCost, error) {
+func calcNodeCost(def ast.Node, fragmentCosts map[string]int, variables map[string]any) (*QueryCost, error) {
 	// NOTE: When we encounter errors in our visit funcs we return
 	// visitor.ActionBreak to stop walking the tree and set the top level err
 	// variable so that it is returned
@@ -177,11 +177,11 @@ func calcNodeCost(def ast.Node, fragmentCosts map[string]int, variables map[stri
 		multiplier = multiplier / currentLimit
 	}
 
-	nonNullVariables := make(map[string]interface{})
-	defaultValues := make(map[string]interface{})
+	nonNullVariables := make(map[string]any)
+	defaultValues := make(map[string]any)
 
 	v := &visitor.VisitorOptions{
-		Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Enter: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.SelectionSet:
 				depth++
@@ -279,7 +279,7 @@ func calcNodeCost(def ast.Node, fragmentCosts map[string]int, variables map[stri
 			}
 			return visitor.ActionNoChange, nil
 		},
-		Leave: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Leave: func(p visitor.VisitFuncParams) (string, any) {
 			switch p.Node.(type) {
 			case *ast.SelectionSet:
 				depth--
@@ -313,7 +313,7 @@ func getFragmentDependencies(node ast.Node) map[string]struct{} {
 	deps := make(map[string]struct{})
 
 	v := &visitor.VisitorOptions{
-		Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Enter: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.FragmentSpread:
 				deps[node.Name.Value] = struct{}{}
@@ -327,7 +327,7 @@ func getFragmentDependencies(node ast.Node) map[string]struct{} {
 	return deps
 }
 
-func extractInt(i interface{}) (int, error) {
+func extractInt(i any) (int, error) {
 	switch v := i.(type) {
 	case int:
 		return v, nil

--- a/cmd/frontend/graphqlbackend/rate_limit_test.go
+++ b/cmd/frontend/graphqlbackend/rate_limit_test.go
@@ -17,7 +17,7 @@ func TestEstimateQueryCost(t *testing.T) {
 	for _, tc := range []struct {
 		name      string
 		query     string
-		variables map[string]interface{}
+		variables map[string]any
 		want      QueryCost
 	}{
 		{
@@ -87,7 +87,7 @@ query Extensions($first: Int!, $prioritizeExtensionIDs: [String!]!) {
                     }
                 }
 `,
-			variables: map[string]interface{}{
+			variables: map[string]any{
 				"first": 10,
 			},
 			want: QueryCost{
@@ -107,7 +107,7 @@ query fetchExternalServices($first: Int = 10){
   }
 }
 `,
-			variables: map[string]interface{}{
+			variables: map[string]any{
 				"first": 5,
 			},
 			want: QueryCost{
@@ -127,7 +127,7 @@ query fetchExternalServices($first: Int = 10){
   }
 }
 `,
-			variables: map[string]interface{}{},
+			variables: map[string]any{},
 			want: QueryCost{
 				FieldCount: 21,
 				MaxDepth:   3,
@@ -355,7 +355,7 @@ fragment FileDiffFields on FileDiff {
 				FieldCount: 7,
 				MaxDepth:   5,
 			},
-			variables: map[string]interface{}{
+			variables: map[string]any{
 				"base": "a46cf4a8b6dc42ea7b7b716e53c49dd3508a8678",
 				"head": "0fd3fb1f4e41ae1f95970beeec1c1f7b2d8a7d06",
 				"repo": "github.com/presslabs/mysql-operator",

--- a/cmd/frontend/graphqlbackend/repositories_test.go
+++ b/cmd/frontend/graphqlbackend/repositories_test.go
@@ -69,7 +69,7 @@ func TestRepositories(t *testing.T) {
 			`,
 			ExpectedErrors: []*gqlerrors.QueryError{
 				{
-					Path:          []interface{}{"repositories", "totalCount"},
+					Path:          []any{"repositories", "totalCount"},
 					Message:       backend.ErrMustBeSiteAdmin.Error(),
 					ResolverError: backend.ErrMustBeSiteAdmin,
 				},
@@ -449,7 +449,7 @@ func TestRepositories_CursorPagination(t *testing.T) {
 				ExpectedResult: "null",
 				ExpectedErrors: []*gqlerrors.QueryError{
 					{
-						Path:          []interface{}{"repositories"},
+						Path:          []any{"repositories"},
 						Message:       `cannot unmarshal repository cursor type: ""`,
 						ResolverError: errors.Errorf(`cannot unmarshal repository cursor type: ""`),
 					},

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -36,7 +36,7 @@ import (
 
 var mockCount = func(_ context.Context, options database.ReposListOptions) (int, error) { return 0, nil }
 
-func assertEqual(t *testing.T, got, want interface{}) {
+func assertEqual(t *testing.T, got, want any) {
 	t.Helper()
 
 	if diff := cmp.Diff(got, want); diff != "" {

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -35,7 +35,7 @@ import (
 
 func TestSearch(t *testing.T) {
 	type Results struct {
-		Results     []interface{}
+		Results     []any
 		ResultCount int
 	}
 	tcs := []struct {
@@ -97,7 +97,7 @@ func TestSearch(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			conf.Mock(&conf.Unified{})
 			defer conf.Mock(nil)
-			vars := map[string]interface{}{"query": tc.searchQuery, "version": tc.searchVersion}
+			vars := map[string]any{"query": tc.searchQuery, "version": tc.searchVersion}
 
 			mockDecodedViewerFinalSettings = &schema.Settings{}
 			defer func() { mockDecodedViewerFinalSettings = nil }()

--- a/cmd/frontend/graphqlbackend/settings_cascade.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade.go
@@ -153,9 +153,9 @@ var deeplyMergedSettingsFields = map[string]int{
 // deeplyMergedSettingsFields.
 func mergeSettings(jsonSettingsStrings []string) ([]byte, error) {
 	var errs []error
-	merged := map[string]interface{}{}
+	merged := map[string]any{}
 	for _, s := range jsonSettingsStrings {
-		var o map[string]interface{}
+		var o map[string]any
 		if err := jsonc.Unmarshal(s, &o); err != nil {
 			errs = append(errs, err)
 		}
@@ -174,16 +174,16 @@ func mergeSettings(jsonSettingsStrings []string) ([]byte, error) {
 	return out, errors.Errorf("errors merging settings: %q", errs)
 }
 
-func mergeSettingsValues(dst map[string]interface{}, field string, value interface{}, depth int) {
+func mergeSettingsValues(dst map[string]any, field string, value any, depth int) {
 	// Try to deeply merge this field.
 	if depth > 0 {
-		if mv, ok := dst[field].([]interface{}); dst[field] == nil || ok {
-			if cv, ok := value.([]interface{}); dst[field] != nil || (value != nil && ok) {
+		if mv, ok := dst[field].([]any); dst[field] == nil || ok {
+			if cv, ok := value.([]any); dst[field] != nil || (value != nil && ok) {
 				dst[field] = append(mv, cv...)
 				return
 			}
-		} else if mv, ok := dst[field].(map[string]interface{}); dst[field] == nil || ok {
-			if cv, ok := value.(map[string]interface{}); dst[field] != nil || (value != nil && ok) {
+		} else if mv, ok := dst[field].(map[string]any); dst[field] == nil || ok {
+			if cv, ok := value.(map[string]any); dst[field] != nil || (value != nil && ok) {
 				for key, value := range cv {
 					mergeSettingsValues(mv, key, value, depth-1)
 				}

--- a/cmd/frontend/graphqlbackend/settings_cascade_test.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade_test.go
@@ -149,7 +149,7 @@ func TestSubjects(t *testing.T) {
 }
 
 func jsonDeepEqual(a, b string) bool {
-	var va, vb interface{}
+	var va, vb any
 	if err := json.Unmarshal([]byte(a), &va); err != nil {
 		panic(err)
 	}

--- a/cmd/frontend/graphqlbackend/settings_mutation.go
+++ b/cmd/frontend/graphqlbackend/settings_mutation.go
@@ -125,7 +125,7 @@ func (r *settingsMutation) EditSettings(ctx context.Context, args *struct {
 	}
 
 	remove := args.Edit.Value == nil
-	var value interface{}
+	var value any
 	if args.Edit.Value != nil {
 		value = args.Edit.Value.Value
 	}
@@ -146,7 +146,7 @@ func (r *settingsMutation) EditConfiguration(ctx context.Context, args *struct {
 	return r.EditSettings(ctx, args)
 }
 
-func (r *settingsMutation) editSettings(ctx context.Context, keyPath jsonx.Path, value interface{}, remove bool) (*updateSettingsPayload, error) {
+func (r *settingsMutation) editSettings(ctx context.Context, keyPath jsonx.Path, value any, remove bool) (*updateSettingsPayload, error) {
 	_, err := r.doUpdateSettings(ctx, func(oldSettings string) (edits []jsonx.Edit, err error) {
 		if remove {
 			edits, _, err = jsonx.ComputePropertyRemoval(oldSettings, keyPath, conf.FormatOptions)

--- a/cmd/frontend/graphqlbackend/settings_mutation_test.go
+++ b/cmd/frontend/graphqlbackend/settings_mutation_test.go
@@ -47,7 +47,7 @@ func TestSettingsMutation_EditSettings(t *testing.T) {
 					}
 				}
 			`,
-			Variables: map[string]interface{}{"value": map[string]int{"x": 123}},
+			Variables: map[string]any{"value": map[string]int{"x": 123}},
 			ExpectedResult: `
 				{
 					"settingsMutation": {
@@ -94,7 +94,7 @@ func TestSettingsMutation_OverwriteSettings(t *testing.T) {
 					}
 				}
 			`,
-			Variables: map[string]interface{}{"contents": "x"},
+			Variables: map[string]any{"contents": "x"},
 			ExpectedResult: `
 				{
 					"settingsMutation": {

--- a/cmd/frontend/graphqlbackend/settings_subject.go
+++ b/cmd/frontend/graphqlbackend/settings_subject.go
@@ -168,7 +168,7 @@ func (s *settingsSubject) ConfigurationCascade() (*settingsCascade, error) {
 }
 
 // readSettings unmarshals s's latest settings into v.
-func (s *settingsSubject) readSettings(ctx context.Context, v interface{}) error {
+func (s *settingsSubject) readSettings(ctx context.Context, v any) error {
 	settings, err := s.LatestSettings(ctx)
 	if err != nil {
 		return err

--- a/cmd/frontend/graphqlbackend/testing.go
+++ b/cmd/frontend/graphqlbackend/testing.go
@@ -45,7 +45,7 @@ type Test struct {
 	Schema         *graphql.Schema
 	Query          string
 	OperationName  string
-	Variables      map[string]interface{}
+	Variables      map[string]any
 	ExpectedResult string
 	ExpectedErrors []*gqlerrors.QueryError
 }
@@ -101,7 +101,7 @@ func RunTest(t *testing.T, test *Test) {
 }
 
 func formatJSON(data []byte) ([]byte, error) {
-	var v interface{}
+	var v any
 	if err := json.Unmarshal(data, &v); err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/user_emails_test.go
+++ b/cmd/frontend/graphqlbackend/user_emails_test.go
@@ -184,7 +184,7 @@ func TestResendUserEmailVerification(t *testing.T) {
 					ExpectedResult: "null",
 					ExpectedErrors: []*gqlerrors.QueryError{
 						{
-							Path:          []interface{}{"resendVerificationEmail"},
+							Path:          []any{"resendVerificationEmail"},
 							Message:       "oh no!",
 							ResolverError: errors.New("oh no!"),
 						},
@@ -214,7 +214,7 @@ func TestResendUserEmailVerification(t *testing.T) {
 					ExpectedErrors: []*gqlerrors.QueryError{
 						{
 							Message:       "Last verification email sent too recently",
-							Path:          []interface{}{"resendVerificationEmail"},
+							Path:          []any{"resendVerificationEmail"},
 							ResolverError: errors.New("Last verification email sent too recently"),
 						},
 					},

--- a/cmd/frontend/graphqlbackend/user_test.go
+++ b/cmd/frontend/graphqlbackend/user_test.go
@@ -89,7 +89,7 @@ func TestUser(t *testing.T) {
 						ExpectedResult: `{"user": null}`,
 						ExpectedErrors: []*gqlerrors.QueryError{
 							{
-								Path:          []interface{}{"user"},
+								Path:          []any{"user"},
 								Message:       wantErr,
 								ResolverError: errors.New(wantErr),
 							},

--- a/cmd/frontend/hubspot/contacts.go
+++ b/cmd/frontend/hubspot/contacts.go
@@ -76,7 +76,7 @@ type apiProperty struct {
 	Value    string `json:"value"`
 }
 
-func (h *apiProperties) set(property string, value interface{}) {
+func (h *apiProperties) set(property string, value any) {
 	if h.Properties == nil {
 		h.Properties = make([]*apiProperty, 0)
 	}

--- a/cmd/frontend/hubspot/forms.go
+++ b/cmd/frontend/hubspot/forms.go
@@ -10,7 +10,7 @@ import "net/url"
 // in the struct) must be snake case, per HubSpot conventions.
 //
 // See https://developers.hubspot.com/docs/methods/forms/submit_form.
-func (c *Client) SubmitForm(formID string, params interface{}) error {
+func (c *Client) SubmitForm(formID string, params any) error {
 	return c.postForm("SubmitForm", c.baseFormURL(), formID, params)
 }
 

--- a/cmd/frontend/hubspot/hubspot.go
+++ b/cmd/frontend/hubspot/hubspot.go
@@ -32,7 +32,7 @@ func New(portalID, hapiKey string) *Client {
 
 // Send a POST request with form data to HubSpot APIs that accept
 // application/x-www-form-urlencoded data (e.g. the Forms API)
-func (c *Client) postForm(methodName string, baseURL *url.URL, suffix string, body interface{}) error {
+func (c *Client) postForm(methodName string, baseURL *url.URL, suffix string, body any) error {
 	var data url.Values
 	switch body := body.(type) {
 	case map[string]string:
@@ -73,7 +73,7 @@ func (c *Client) postForm(methodName string, baseURL *url.URL, suffix string, bo
 
 // Send a POST request with JSON data to HubSpot APIs that accept JSON
 // (e.g. the Contacts, Lists, etc APIs)
-func (c *Client) postJSON(methodName string, baseURL *url.URL, reqPayload, respPayload interface{}) error {
+func (c *Client) postJSON(methodName string, baseURL *url.URL, reqPayload, respPayload any) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 

--- a/cmd/frontend/internal/app/go_symbol_url.go
+++ b/cmd/frontend/internal/app/go_symbol_url.go
@@ -429,7 +429,7 @@ func IsAbs(path string) bool {
 // the stack trace appended. Arguments are handled in the manner of
 // fmt.Printf. Arguments should format to a string which identifies what the
 // panic code was doing. Returns a non-nil error if it recovered from a panic.
-func Panicf(r interface{}, format string, v ...interface{}) error {
+func Panicf(r any, format string, v ...any) error {
 	if r != nil {
 		// Same as net/http
 		const size = 64 << 10

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -361,9 +361,8 @@ func initRouter(db dbutil.DB, router *mux.Router) {
 // The scheme, host, and path in the specified url override ones in the incoming
 // request. For example:
 //
-// 	staticRedirectHandler("http://google.com") serving "https://sourcegraph.com/foobar?q=foo" -> "http://google.com/foobar?q=foo"
-// 	staticRedirectHandler("/foo") serving "https://sourcegraph.com/bar?q=foo" -> "https://sourcegraph.com/foo?q=foo"
-//
+//	staticRedirectHandler("http://google.com") serving "https://sourcegraph.com/foobar?q=foo" -> "http://google.com/foobar?q=foo"
+//	staticRedirectHandler("/foo") serving "https://sourcegraph.com/bar?q=foo" -> "https://sourcegraph.com/foo?q=foo"
 func staticRedirectHandler(u string, code int) http.Handler {
 	target, err := url.Parse(u)
 	if err != nil {
@@ -403,9 +402,8 @@ func limitString(s string, n int, ellipsis bool) string {
 // Clients that wish to return their own HTTP status code should use this from
 // their handler:
 //
-// 	serveError(w, r, err, http.MyStatusCode)
-//  return nil
-//
+//		serveError(w, r, err, http.MyStatusCode)
+//	 return nil
 func handler(f func(w http.ResponseWriter, r *http.Request) error) http.Handler {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() {
@@ -421,7 +419,7 @@ func handler(f func(w http.ResponseWriter, r *http.Request) error) http.Handler 
 }
 
 type recoverError struct {
-	recover interface{}
+	recover any
 	stack   []byte
 }
 
@@ -527,7 +525,7 @@ func serveErrorNoDebug(w http.ResponseWriter, r *http.Request, err error, status
 // serveErrorTest makes it easy to test styling/layout of the error template by
 // visiting:
 //
-// 	http://localhost:3080/__errorTest?nodebug=true&error=theerror&status=500
+//	http://localhost:3080/__errorTest?nodebug=true&error=theerror&status=500
 //
 // The `nodebug=true` parameter hides error messages (which is ALWAYS the case
 // in production), `error` controls the error message text, and status controls

--- a/cmd/frontend/internal/app/ui/tmpl.go
+++ b/cmd/frontend/internal/app/ui/tmpl.go
@@ -118,7 +118,7 @@ func doLoadTemplate(path string) (*template.Template, error) {
 // is its file name, relative to the template directory.
 //
 // The given data is accessible in the template via $.Foobar
-func renderTemplate(w http.ResponseWriter, name string, data interface{}) error {
+func renderTemplate(w http.ResponseWriter, name string, data any) error {
 	root, err := loadTemplate(name)
 	if err != nil {
 		return err

--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -254,7 +254,7 @@ func getAndMarshalCodeHostVersionsJSON(ctx context.Context, db dbutil.DB) (_ jso
 	return json.Marshal(versions)
 }
 
-func getDependencyVersions(ctx context.Context, db dbutil.DB, logFunc func(string, ...interface{})) (json.RawMessage, error) {
+func getDependencyVersions(ctx context.Context, db dbutil.DB, logFunc func(string, ...any)) (json.RawMessage, error) {
 	var (
 		err error
 		dv  dependencyVersions

--- a/cmd/frontend/internal/app/updatecheck/handler_test.go
+++ b/cmd/frontend/internal/app/updatecheck/handler_test.go
@@ -768,12 +768,12 @@ func TestSerializeCodeHostVersions(t *testing.T) {
 }
 
 func compareJSON(t *testing.T, actual []byte, expected string) {
-	var o1 interface{}
+	var o1 any
 	if err := json.Unmarshal(actual, &o1); err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}
 
-	var o2 interface{}
+	var o2 any
 	if err := json.Unmarshal([]byte(expected), &o2); err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}

--- a/cmd/frontend/internal/app/verify_email.go
+++ b/cmd/frontend/internal/app/verify_email.go
@@ -83,7 +83,7 @@ func logEmailVerified(ctx context.Context, db dbutil.DB, r *http.Request, userID
 	database.SecurityEventLogs(db).LogEvent(ctx, event)
 }
 
-func httpLogAndError(w http.ResponseWriter, msg string, code int, errArgs ...interface{}) {
+func httpLogAndError(w http.ResponseWriter, msg string, code int, errArgs ...any) {
 	log15.Error(msg, errArgs...)
 	http.Error(w, msg, code)
 }

--- a/cmd/frontend/internal/auth/userpasswd/handlers.go
+++ b/cmd/frontend/internal/auth/userpasswd/handlers.go
@@ -308,7 +308,7 @@ func HandleCheckUsernameTaken(db dbutil.DB) func(w http.ResponseWriter, r *http.
 	}
 }
 
-func httpLogAndError(w http.ResponseWriter, msg string, code int, errArgs ...interface{}) {
+func httpLogAndError(w http.ResponseWriter, msg string, code int, errArgs ...any) {
 	log15.Error(msg, errArgs...)
 	http.Error(w, msg, code)
 }

--- a/cmd/frontend/internal/cli/loghandlers/loghandlers_test.go
+++ b/cmd/frontend/internal/cli/loghandlers/loghandlers_test.go
@@ -83,7 +83,7 @@ func TestTrace_Threshold(t *testing.T) {
 	}
 }
 
-func mkRecord(lvl log15.Lvl, msg string, ctx ...interface{}) log15.Record {
+func mkRecord(lvl log15.Lvl, msg string, ctx ...any) log15.Record {
 	return log15.Record{
 		Lvl: lvl,
 		Msg: msg,

--- a/cmd/frontend/internal/confdb/confdb.go
+++ b/cmd/frontend/internal/confdb/confdb.go
@@ -172,6 +172,6 @@ func parseQueryRows(ctx context.Context, rows *sql.Rows) ([]*SiteConfig, error) 
 // queryable allows us to reuse the same logic for certain operations both
 // inside and outside an explicit transaction.
 type queryable interface {
-	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
-	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 }

--- a/cmd/frontend/internal/httpapi/graphql.go
+++ b/cmd/frontend/internal/httpapi/graphql.go
@@ -126,9 +126,9 @@ func serveGraphQL(schema *graphql.Schema, rlw graphqlbackend.LimitWatcher, isInt
 }
 
 type graphQLQueryParams struct {
-	Query         string                 `json:"query"`
-	OperationName string                 `json:"operationName"`
-	Variables     map[string]interface{} `json:"variables"`
+	Query         string         `json:"query"`
+	OperationName string         `json:"operationName"`
+	Variables     map[string]any `json:"variables"`
 }
 
 type traceData struct {

--- a/cmd/frontend/internal/httpapi/helpers.go
+++ b/cmd/frontend/internal/httpapi/helpers.go
@@ -8,10 +8,10 @@ import (
 
 // writeJSON writes a JSON Content-Type header and a JSON-encoded object to the
 // http.ResponseWriter.
-func writeJSON(w http.ResponseWriter, v interface{}) error {
+func writeJSON(w http.ResponseWriter, v any) error {
 	// Return "[]" instead of "null" if v is a nil slice.
 	if reflect.TypeOf(v).Kind() == reflect.Slice && reflect.ValueOf(v).IsNil() {
-		v = []interface{}{}
+		v = []any{}
 	}
 
 	// MarshalIndent takes about 30-50% longer, which

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -97,9 +97,9 @@ func serveExternalServiceConfigs(db dbutil.DB) func(w http.ResponseWriter, r *ht
 		// the array of configs (which are themselves JSON objects).
 		// This makes it possible for the caller to directly unmarshal the response into
 		// a slice of connection configurations for this external service kind.
-		configs := make([]map[string]interface{}, 0, len(services))
+		configs := make([]map[string]any, 0, len(services))
 		for _, service := range services {
-			var config map[string]interface{}
+			var config map[string]any
 			// Raw configs may have comments in them so we have to use a json parser
 			// that supports comments in json.
 			if err := jsonc.Unmarshal(service.Config, &config); err != nil {

--- a/cmd/frontend/internal/httpapi/repo_shield_test.go
+++ b/cmd/frontend/internal/httpapi/repo_shield_test.go
@@ -33,7 +33,7 @@ func TestRepoShieldFmt(t *testing.T) {
 func TestRepoShield(t *testing.T) {
 	c := newTest()
 
-	wantResp := map[string]interface{}{
+	wantResp := map[string]any{
 		"value": " 200 projects",
 	}
 
@@ -58,7 +58,7 @@ func TestRepoShield(t *testing.T) {
 		return 200, nil
 	}
 
-	var resp map[string]interface{}
+	var resp map[string]any
 	if err := c.GetJSON("/repos/github.com/gorilla/mux/-/shield", &resp); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handle_repo_authz_event.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handle_repo_authz_event.go
@@ -20,7 +20,7 @@ import (
 
 // handleGithubRepoAuthzEvent handles any github event containing a repository field, and enqueues the contained
 // repo for permissions synchronisation.
-func handleGitHubRepoAuthzEvent(ctx context.Context, extSvc *types.ExternalService, payload interface{}) error {
+func handleGitHubRepoAuthzEvent(ctx context.Context, extSvc *types.ExternalService, payload any) error {
 	if !conf.ExperimentalFeatures().EnablePermissionsWebhooks {
 		return nil
 	}

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handle_user_authz_event.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handle_user_authz_event.go
@@ -21,8 +21,8 @@ import (
 
 // handleGitHubUserAuthzEvent handles a github webhook for the events described in webhookhandlers/handlers.go
 // extracting a user from the github event and scheduling it for a perms update in repo-updater
-func handleGitHubUserAuthzEvent(db dbutil.DB) func(ctx context.Context, extSvc *types.ExternalService, payload interface{}) error {
-	return func(ctx context.Context, extSvc *types.ExternalService, payload interface{}) error {
+func handleGitHubUserAuthzEvent(db dbutil.DB) func(ctx context.Context, extSvc *types.ExternalService, payload any) error {
+	return func(ctx context.Context, extSvc *types.ExternalService, payload any) error {
 		if !conf.ExperimentalFeatures().EnablePermissionsWebhooks {
 			return nil
 		}

--- a/cmd/frontend/internal/search/logs/logs.go
+++ b/cmd/frontend/internal/search/logs/logs.go
@@ -19,7 +19,7 @@ func LogSlowSearchesThreshold() time.Duration {
 }
 
 // MapToLog15Ctx translates a map to log15 context fields.
-func MapToLog15Ctx(m map[string]interface{}) []interface{} {
+func MapToLog15Ctx(m map[string]any) []any {
 	// sort so its stable
 	keys := make([]string, len(m))
 	i := 0
@@ -28,7 +28,7 @@ func MapToLog15Ctx(m map[string]interface{}) []interface{} {
 		i++
 	}
 	sort.Strings(keys)
-	ctx := make([]interface{}, len(m)*2)
+	ctx := make([]any, len(m)*2)
 	for i, k := range keys {
 		j := i * 2
 		ctx[j] = k

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -82,7 +82,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Always send a final done event so clients know the stream is shutting
 	// down.
-	defer eventWriter.Event("done", map[string]interface{}{})
+	defer eventWriter.Event("done", map[string]any{})
 
 	// Log events to trace
 	eventWriter.StatHook = eventStreamOTHook(tr.LogFields)
@@ -599,7 +599,7 @@ type jsonArrayBuf struct {
 
 // Append marshals v and adds it to the json array buffer. If the size of the
 // buffer exceed FlushSize the buffer is written out.
-func (j *jsonArrayBuf) Append(v interface{}) error {
+func (j *jsonArrayBuf) Append(v any) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err

--- a/cmd/frontend/internal/session/session.go
+++ b/cmd/frontend/internal/session/session.go
@@ -186,7 +186,7 @@ func waitForRedis(s *redistore.RediStore) {
 // session exists, a new session is created.
 //
 // The value is JSON-encoded before being stored.
-func SetData(w http.ResponseWriter, r *http.Request, key string, value interface{}) error {
+func SetData(w http.ResponseWriter, r *http.Request, key string, value any) error {
 	session, err := sessionStore.Get(r, cookieName)
 	if err != nil {
 		return errors.WithMessage(err, "getting session")
@@ -206,7 +206,7 @@ func SetData(w http.ResponseWriter, r *http.Request, key string, value interface
 // be a pointer).
 //
 // The value is JSON-decoded from the raw bytes stored by the call to SetData.
-func GetData(r *http.Request, key string, value interface{}) error {
+func GetData(r *http.Request, key string, value any) error {
 	session, err := sessionStore.Get(r, cookieName)
 	if err != nil {
 		return errors.WithMessage(err, "getting session")
@@ -303,9 +303,9 @@ func CookieMiddleware(next http.Handler) http.Handler {
 //
 // - The request originates from the same origin. -OR-
 //
-// - The request is cross-origin but passed the CORS preflight check (because otherwise the
-//   preflight OPTIONS response from secureHeadersMiddleware would have caused the browser to refuse
-//   to send this HTTP request).
+//   - The request is cross-origin but passed the CORS preflight check (because otherwise the
+//     preflight OPTIONS response from secureHeadersMiddleware would have caused the browser to refuse
+//     to send this HTTP request).
 //
 // To determine if it's a non-simple CORS request, it checks for the presence of either
 // "Content-Type: application/json; charset=utf-8" or a non-empty HTTP request header whose name is

--- a/cmd/frontend/internal/siteid/siteid_test.go
+++ b/cmd/frontend/internal/siteid/siteid_test.go
@@ -29,7 +29,7 @@ func TestGet(t *testing.T) {
 
 	{
 		origFatalln := fatalln
-		fatalln = func(v ...interface{}) { panic(v) }
+		fatalln = func(v ...any) { panic(v) }
 		defer func() { fatalln = origFatalln }()
 	}
 

--- a/cmd/frontend/registry/api/extension_graphql.go
+++ b/cmd/frontend/registry/api/extension_graphql.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	graphqlbackend.NodeToRegistryExtension = func(node interface{}) (graphqlbackend.RegistryExtension, bool) {
+	graphqlbackend.NodeToRegistryExtension = func(node any) (graphqlbackend.RegistryExtension, bool) {
 		switch n := node.(type) {
 		case *registryExtensionRemoteResolver:
 			return n, true

--- a/cmd/frontend/registry/client/client.go
+++ b/cmd/frontend/registry/client/client.go
@@ -88,7 +88,7 @@ func (e *notFoundError) Error() string {
 	return fmt.Sprintf("extension not found with %s %q", e.field, e.value)
 }
 
-func httpGet(ctx context.Context, op, urlStr string, result interface{}) (err error) {
+func httpGet(ctx context.Context, op, urlStr string, result any) (err error) {
 	defer func() { err = errors.Wrap(err, remoteRegistryErrorMessage) }()
 
 	req, err := http.NewRequest("GET", urlStr, nil)

--- a/cmd/frontend/webhooks/github_webhooks.go
+++ b/cmd/frontend/webhooks/github_webhooks.go
@@ -26,7 +26,7 @@ type Registerer interface {
 // WebhookHandler is a handler for a webhook event, the 'event' param could be any of the event types
 // permissible based on the event type(s) the handler was registered against. If you register a handler
 // for many event types, you should do a type switch within your handler
-type WebhookHandler func(ctx context.Context, extSvc *types.ExternalService, event interface{}) error
+type WebhookHandler func(ctx context.Context, extSvc *types.ExternalService, event any) error
 
 // GitHubWebhook is responsible for handling incoming http requests for github webhooks
 // and routing to any registered WebhookHandlers, events are routed by their event type,
@@ -74,7 +74,7 @@ func (h *GitHubWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // Dispatch accepts an event for a particular event type and dispatches it
 // to the appropriate stack of handlers, if any are configured.
-func (h *GitHubWebhook) Dispatch(ctx context.Context, eventType string, extSvc *types.ExternalService, e interface{}) error {
+func (h *GitHubWebhook) Dispatch(ctx context.Context, eventType string, extSvc *types.ExternalService, e any) error {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	g := errgroup.Group{}
@@ -163,7 +163,7 @@ func (h *GitHubWebhook) findAndValidateExternalService(ctx context.Context, sig 
 	}
 
 	for _, e := range es {
-		var c interface{}
+		var c any
 		c, err = e.Configuration()
 		if err != nil {
 			return nil, err

--- a/cmd/frontend/webhooks/github_webhooks_test.go
+++ b/cmd/frontend/webhooks/github_webhooks_test.go
@@ -28,7 +28,7 @@ var dsn = flag.String("dsn", "", "Database connection string to use in integrati
 func TestGithubWebhookDispatchSuccess(t *testing.T) {
 	h := GitHubWebhook{}
 	var called bool
-	h.Register(func(ctx context.Context, svc *types.ExternalService, payload interface{}) error {
+	h.Register(func(ctx context.Context, svc *types.ExternalService, payload any) error {
 		called = true
 		return nil
 	}, "test-event-1")
@@ -56,11 +56,11 @@ func TestGithubWebhookDispatchSuccessMultiple(t *testing.T) {
 		h      = GitHubWebhook{}
 		called = make(chan struct{}, 2)
 	)
-	h.Register(func(ctx context.Context, svc *types.ExternalService, payload interface{}) error {
+	h.Register(func(ctx context.Context, svc *types.ExternalService, payload any) error {
 		called <- struct{}{}
 		return nil
 	}, "test-event-1")
-	h.Register(func(ctx context.Context, svc *types.ExternalService, payload interface{}) error {
+	h.Register(func(ctx context.Context, svc *types.ExternalService, payload any) error {
 		called <- struct{}{}
 		return nil
 	}, "test-event-1")
@@ -79,11 +79,11 @@ func TestGithubWebhookDispatchError(t *testing.T) {
 		h      = GitHubWebhook{}
 		called = make(chan struct{}, 2)
 	)
-	h.Register(func(ctx context.Context, svc *types.ExternalService, payload interface{}) error {
+	h.Register(func(ctx context.Context, svc *types.ExternalService, payload any) error {
 		called <- struct{}{}
 		return errors.Errorf("oh no")
 	}, "test-event-1")
-	h.Register(func(ctx context.Context, svc *types.ExternalService, payload interface{}) error {
+	h.Register(func(ctx context.Context, svc *types.ExternalService, payload any) error {
 		called <- struct{}{}
 		return nil
 	}, "test-event-1")
@@ -138,7 +138,7 @@ func TestGithubWebhookExternalServices(t *testing.T) {
 	}
 
 	var called bool
-	hook.Register(func(ctx context.Context, extSvc *types.ExternalService, payload interface{}) error {
+	hook.Register(func(ctx context.Context, extSvc *types.ExternalService, payload any) error {
 		evt, ok := payload.(*gh.PublicEvent)
 		if !ok {
 			t.Errorf("Expected *gh.PublicEvent event, got %T", payload)
@@ -181,7 +181,7 @@ func TestGithubWebhookExternalServices(t *testing.T) {
 	}
 }
 
-func marshalJSON(t testing.TB, v interface{}) string {
+func marshalJSON(t testing.TB, v any) string {
 	t.Helper()
 
 	bs, err := json.Marshal(v)

--- a/cmd/gitserver/server/customfetch.go
+++ b/cmd/gitserver/server/customfetch.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-var customGitFetch = conf.Cached(func() interface{} {
+var customGitFetch = conf.Cached(func() any {
 	return buildCustomFetchMappings(conf.Get().ExperimentalFeatures.CustomGitFetch)
 })
 

--- a/cmd/gitserver/server/customfetch_test.go
+++ b/cmd/gitserver/server/customfetch_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestEmptyCustomGitFetch(t *testing.T) {
-	customGitFetch = func() interface{} {
+	customGitFetch = func() any {
 		return buildCustomFetchMappings(nil)
 	}
 
@@ -58,7 +58,7 @@ func TestCustomGitFetch(t *testing.T) {
 		},
 	}
 
-	customGitFetch = func() interface{} {
+	customGitFetch = func() any {
 		return buildCustomFetchMappings(mappings)
 	}
 

--- a/cmd/gitserver/server/gitolite_phabricator_test.go
+++ b/cmd/gitserver/server/gitolite_phabricator_test.go
@@ -19,7 +19,7 @@ func TestServer_handleGet(t *testing.T) {
 			Url:             "https://phab.mycompany.com",
 		},
 	}}
-	api.MockExternalServiceConfigs = func(kind string, result interface{}) error {
+	api.MockExternalServiceConfigs = func(kind string, result any) error {
 		buf, err := json.Marshal(conn)
 		if err != nil {
 			return err
@@ -62,7 +62,7 @@ func TestServer_handleGet_invalid(t *testing.T) {
 			CallsignCommand: `echo "Something went wrong this is not a valid callsign"`,
 		},
 	}}
-	api.MockExternalServiceConfigs = func(kind string, result interface{}) error {
+	api.MockExternalServiceConfigs = func(kind string, result any) error {
 		buf, err := json.Marshal(conn)
 		if err != nil {
 			return err

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -29,7 +29,7 @@ import (
 // GitDir is an absolute path to a GIT_DIR.
 // They will all follow the form:
 //
-//    ${s.ReposDir}/${name}/.git
+//	${s.ReposDir}/${name}/.git
 type GitDir string
 
 // Path is a helper which returns filepath.Join(dir, elem...)
@@ -102,7 +102,7 @@ type tlsConfig struct {
 	SSLCAInfo string
 }
 
-var tlsExternal = conf.Cached(func() interface{} {
+var tlsExternal = conf.Cached(func() any {
 	c := conf.Get().ExperimentalFeatures.TlsExternal
 
 	if c == nil {
@@ -522,7 +522,7 @@ func (w *progressWriter) Bytes() []byte {
 }
 
 // mapToLog15Ctx translates a map to log15 context fields.
-func mapToLog15Ctx(m map[string]interface{}) []interface{} {
+func mapToLog15Ctx(m map[string]any) []any {
 	// sort so its stable
 	keys := make([]string, len(m))
 	i := 0
@@ -531,7 +531,7 @@ func mapToLog15Ctx(m map[string]interface{}) []interface{} {
 		i++
 	}
 	sort.Strings(keys)
-	ctx := make([]interface{}, len(m)*2)
+	ctx := make([]any, len(m)*2)
 	for i, k := range keys {
 		j := i * 2
 		ctx[j] = k

--- a/cmd/loadtest/main.go
+++ b/cmd/loadtest/main.go
@@ -89,15 +89,15 @@ type GraphQLResponseSearch struct {
 	Data struct {
 		Search struct {
 			Results struct {
-				Results []interface{} `json:"results"`
+				Results []any `json:"results"`
 			} `json:"results"`
 		} `json:"search"`
 	} `json:"data"`
 }
 
 type GraphQLQuery struct {
-	Query     string      `json:"query"`
-	Variables interface{} `json:"variables"`
+	Query     string `json:"query"`
+	Variables any    `json:"variables"`
 }
 
 const gqlSearch = `query Search(

--- a/cmd/query-runner/email.go
+++ b/cmd/query-runner/email.go
@@ -130,7 +130,7 @@ func emailNotifySubscribeUnsubscribe(ctx context.Context, recipient *recipient, 
 	})
 }
 
-func sendEmail(ctx context.Context, userID int32, eventType string, template txtypes.Templates, data interface{}) error {
+func sendEmail(ctx context.Context, userID int32, eventType string, template txtypes.Templates, data any) error {
 	email, err := api.InternalClient.UserEmailsGetEmail(ctx, userID)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("InternalClient.UserEmailsGetEmail for userID=%d", userID))

--- a/cmd/query-runner/graphql.go
+++ b/cmd/query-runner/graphql.go
@@ -17,8 +17,8 @@ import (
 )
 
 type graphQLQuery struct {
-	Query     string      `json:"query"`
-	Variables interface{} `json:"variables"`
+	Query     string `json:"query"`
+	Variables any    `json:"variables"`
 }
 
 const gqlSearchQuery = `query Search(
@@ -113,11 +113,11 @@ type gqlSearchResponse struct {
 				ApproximateResultCount string
 				Cloning                []*api.Repo
 				Timedout               []*api.Repo
-				Results                []interface{}
+				Results                []any
 			}
 		}
 	}
-	Errors []interface{}
+	Errors []any
 }
 
 func search(ctx context.Context, query string) (*gqlSearchResponse, error) {
@@ -162,7 +162,7 @@ func gqlURL(queryName string) (string, error) {
 }
 
 // extractTime extracts the time from the given search result.
-func extractTime(result interface{}) (t *time.Time, err error) {
+func extractTime(result any) (t *time.Time, err error) {
 	// Use recover because we assume the data structure here a lot, for less
 	// error checking.
 	defer func() {
@@ -176,12 +176,12 @@ func extractTime(result interface{}) (t *time.Time, err error) {
 		err = errors.Errorf("failed to extract time from search result")
 	}()
 
-	m := result.(map[string]interface{})
+	m := result.(map[string]any)
 	typeName := m["__typename"].(string)
 	switch typeName {
 	case "CommitSearchResult":
-		commit := m["commit"].(map[string]interface{})
-		author := commit["author"].(map[string]interface{})
+		commit := m["commit"].(map[string]any)
+		author := commit["author"].(map[string]any)
 		date := author["date"].(string)
 
 		// For now, our graphql API commit authorship date is in Go default time format.

--- a/cmd/query-runner/queryrunnerapi/queryrunnerapi.go
+++ b/cmd/query-runner/queryrunnerapi/queryrunnerapi.go
@@ -90,7 +90,7 @@ func (c *client) TestNotification(ctx context.Context, savedSearch api.SavedQuer
 	}
 }
 
-func (c *client) post(path string, data interface{}) error {
+func (c *client) post(path string, data any) error {
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(data); err != nil {
 		return errors.Wrap(err, "Encoding request")

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -85,7 +85,7 @@ func (s *Server) Handler() http.Handler {
 }
 
 // TODO(tsenart): Reuse this function in all handlers.
-func respond(w http.ResponseWriter, code int, v interface{}) {
+func respond(w http.ResponseWriter, code int, v any) {
 	switch val := v.(type) {
 	case error:
 		if val != nil {

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -300,7 +300,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	globals.WatchExternalURL(nil)
 
 	debugserverEndpoints.repoUpdaterStateEndpoint = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		dumps := []interface{}{
+		dumps := []any{
 			scheduler.DebugDump(r.Context(), db),
 		}
 		for _, dumper := range debugDumpers {

--- a/cmd/server/shared/postgres.go
+++ b/cmd/server/shared/postgres.go
@@ -173,7 +173,7 @@ func isPostgresConfigured(prefix string) bool {
 	return os.Getenv(prefix+"PGHOST") != "" || os.Getenv(prefix+"PGDATASOURCE") != ""
 }
 
-func pgPrintf(format string, args ...interface{}) {
+func pgPrintf(format string, args ...any) {
 	_, _ = fmt.Fprintf(os.Stderr, "✱ "+format+"\n", args...)
 }
 

--- a/cmd/worker/shared/db.go
+++ b/cmd/worker/shared/db.go
@@ -19,7 +19,7 @@ func InitDatabase() (*sql.DB, error) {
 	return conn.(*sql.DB), nil
 }
 
-var initDatabaseMemo = NewMemoizedConstructor(func() (interface{}, error) {
+var initDatabaseMemo = NewMemoizedConstructor(func() (any, error) {
 	postgresDSN := WatchServiceConnectionValue(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.PostgresDSN
 	})

--- a/cmd/worker/shared/memo.go
+++ b/cmd/worker/shared/memo.go
@@ -7,20 +7,20 @@ import "sync"
 // underlying constructor being called once. All callers will receive
 // the same return values.
 type MemoizedConstructor struct {
-	ctor  func() (interface{}, error)
-	value interface{}
+	ctor  func() (any, error)
+	value any
 	err   error
 	once  sync.Once
 }
 
 // NewMemoizedConstructor memoizes the given constructor
-func NewMemoizedConstructor(ctor func() (interface{}, error)) *MemoizedConstructor {
+func NewMemoizedConstructor(ctor func() (any, error)) *MemoizedConstructor {
 	return &MemoizedConstructor{ctor: ctor}
 }
 
 // Init ensures that the given constructor has been called exactly
 // once, then returns the constructor's result value and error.
-func (m *MemoizedConstructor) Init() (interface{}, error) {
+func (m *MemoizedConstructor) Init() (any, error) {
 	m.once.Do(func() { m.value, m.err = m.ctor() })
 	return m.value, m.err
 }

--- a/dev/authtest/main_test.go
+++ b/dev/authtest/main_test.go
@@ -71,7 +71,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func mustMarshalJSONString(v interface{}) string {
+func mustMarshalJSONString(v any) string {
 	str, err := jsoniter.MarshalToString(v)
 	if err != nil {
 		panic(err)

--- a/dev/authtest/site_admin_test.go
+++ b/dev/authtest/site_admin_test.go
@@ -80,7 +80,7 @@ func TestSiteAdminEndpoints(t *testing.T) {
 		type gqlTest struct {
 			name      string
 			query     string
-			variables map[string]interface{}
+			variables map[string]any
 		}
 		tests := []gqlTest{
 			{
@@ -185,7 +185,7 @@ mutation CreateAccessToken($userID: ID!) {
 		id
 	}
 }`,
-				variables: map[string]interface{}{
+				variables: map[string]any{
 					"userID": userClient.AuthenticatedUserID(),
 				},
 			}, {

--- a/dev/gqltest/feature_flag_test.go
+++ b/dev/gqltest/feature_flag_test.go
@@ -75,7 +75,7 @@ func TestFeatureFlags(t *testing.T) {
 				CreateFeatureFlag featureFlagResult
 			}
 		}
-		params := map[string]interface{}{"name": name, "value": value, "rollout": rolloutBasisPoints}
+		params := map[string]any{"name": name, "value": value, "rollout": rolloutBasisPoints}
 		err := client.GraphQL("", m, params, &res)
 		return res.Data.CreateFeatureFlag, err
 	}
@@ -97,7 +97,7 @@ func TestFeatureFlags(t *testing.T) {
 				UpdateFeatureFlag featureFlagResult
 			}
 		}
-		params := map[string]interface{}{"name": name, "value": value, "rollout": rolloutBasisPoints}
+		params := map[string]any{"name": name, "value": value, "rollout": rolloutBasisPoints}
 		err := client.GraphQL("", m, params, &res)
 		return res.Data.UpdateFeatureFlag, err
 	}
@@ -110,7 +110,7 @@ func TestFeatureFlags(t *testing.T) {
 				alwaysNil		
 			}
 		}`
-		params := map[string]interface{}{"name": name}
+		params := map[string]any{"name": name}
 		return client.GraphQL("", m, params, nil)
 	}
 
@@ -262,7 +262,7 @@ func TestFeatureFlags(t *testing.T) {
 				CreateFeatureFlagOverride featureFlagOverrideResult
 			}
 		}
-		params := map[string]interface{}{"namespace": namespace, "flagName": flagName, "value": value}
+		params := map[string]any{"namespace": namespace, "flagName": flagName, "value": value}
 		err := client.GraphQL("", m, params, &res)
 		return res.Data.CreateFeatureFlagOverride, err
 	}
@@ -283,7 +283,7 @@ func TestFeatureFlags(t *testing.T) {
 				UpdateFeatureFlagOverride featureFlagOverrideResult
 			}
 		}
-		params := map[string]interface{}{"id": id, "value": value}
+		params := map[string]any{"id": id, "value": value}
 		err := client.GraphQL("", m, params, &res)
 		return res.Data.UpdateFeatureFlagOverride, err
 	}
@@ -298,7 +298,7 @@ func TestFeatureFlags(t *testing.T) {
 			}
 		}`
 
-		params := map[string]interface{}{"id": id}
+		params := map[string]any{"id": id}
 		return client.GraphQL("", m, params, nil)
 	}
 

--- a/dev/gqltest/main_test.go
+++ b/dev/gqltest/main_test.go
@@ -78,7 +78,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func mustMarshalJSONString(v interface{}) string {
+func mustMarshalJSONString(v any) string {
 	str, err := jsoniter.MarshalToString(v)
 	if err != nil {
 		panic(err)

--- a/dev/sg/config.go
+++ b/dev/sg/config.go
@@ -60,7 +60,7 @@ type Commandset struct {
 }
 
 // UnmarshalYAML implements the Unmarshaler interface.
-func (c *Commandset) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *Commandset) UnmarshalYAML(unmarshal func(any) error) error {
 	// To be backwards compatible we first try to unmarshal as a simple list.
 	var list []string
 	if err := unmarshal(&list); err == nil {

--- a/dev/sg/internal/migration/migration.go
+++ b/dev/sg/internal/migration/migration.go
@@ -625,7 +625,7 @@ type mLogger struct {
 	prefix string
 }
 
-func (m mLogger) Printf(f string, i ...interface{}) {
+func (m mLogger) Printf(f string, i ...any) {
 	m.block.Writef(m.prefix+strings.TrimSpace(f), i...)
 }
 func (mLogger) Verbose() bool {

--- a/dev/sg/internal/run/logger.go
+++ b/dev/sg/internal/run/logger.go
@@ -26,7 +26,7 @@ type cmdLogger struct {
 	done   chan struct{}
 }
 
-func nameToColor(s string, v ...interface{}) output.Style {
+func nameToColor(s string, v ...any) output.Style {
 	h := fnv.New32()
 	h.Write([]byte(s))
 	// We don't use 256 colors because some of those are too dark/bright and hard to read

--- a/dev/src-expose/serve.go
+++ b/dev/src-expose/serve.go
@@ -79,7 +79,7 @@ func (s *Serve) handler() (http.Handler, error) {
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		err := indexHTML.Execute(w, map[string]interface{}{
+		err := indexHTML.Execute(w, map[string]any{
 			"Explain": explainAddr(s.Addr),
 			"Links": []string{
 				"/v1/list-repos",

--- a/docker-images/prometheus/cmd/prom-wrapper/mocks/prometheus_mock.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/mocks/prometheus_mock.go
@@ -324,14 +324,14 @@ type APIAlertManagersFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c APIAlertManagersFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c APIAlertManagersFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c APIAlertManagersFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c APIAlertManagersFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // APIAlertsFunc describes the behavior when the Alerts method of the parent
@@ -429,14 +429,14 @@ type APIAlertsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c APIAlertsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c APIAlertsFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c APIAlertsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c APIAlertsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // APICleanTombstonesFunc describes the behavior when the CleanTombstones
@@ -532,14 +532,14 @@ type APICleanTombstonesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c APICleanTombstonesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c APICleanTombstonesFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c APICleanTombstonesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c APICleanTombstonesFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // APIConfigFunc describes the behavior when the Config method of the parent
@@ -637,14 +637,14 @@ type APIConfigFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c APIConfigFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c APIConfigFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c APIConfigFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c APIConfigFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // APIDeleteSeriesFunc describes the behavior when the DeleteSeries method
@@ -748,14 +748,14 @@ type APIDeleteSeriesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c APIDeleteSeriesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c APIDeleteSeriesFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c APIDeleteSeriesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c APIDeleteSeriesFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // APIFlagsFunc describes the behavior when the Flags method of the parent
@@ -853,14 +853,14 @@ type APIFlagsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c APIFlagsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c APIFlagsFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c APIFlagsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c APIFlagsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // APILabelNamesFunc describes the behavior when the LabelNames method of
@@ -967,14 +967,14 @@ type APILabelNamesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c APILabelNamesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c APILabelNamesFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c APILabelNamesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c APILabelNamesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // APILabelValuesFunc describes the behavior when the LabelValues method of
@@ -1084,14 +1084,14 @@ type APILabelValuesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c APILabelValuesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c APILabelValuesFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c APILabelValuesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c APILabelValuesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // APIMetadataFunc describes the behavior when the Metadata method of the
@@ -1195,14 +1195,14 @@ type APIMetadataFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c APIMetadataFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c APIMetadataFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c APIMetadataFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c APIMetadataFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // APIQueryFunc describes the behavior when the Query method of the parent
@@ -1309,14 +1309,14 @@ type APIQueryFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c APIQueryFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c APIQueryFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c APIQueryFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c APIQueryFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // APIQueryRangeFunc describes the behavior when the QueryRange method of
@@ -1423,14 +1423,14 @@ type APIQueryRangeFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c APIQueryRangeFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c APIQueryRangeFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c APIQueryRangeFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c APIQueryRangeFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // APIRulesFunc describes the behavior when the Rules method of the parent
@@ -1528,14 +1528,14 @@ type APIRulesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c APIRulesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c APIRulesFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c APIRulesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c APIRulesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // APIRuntimeinfoFunc describes the behavior when the Runtimeinfo method of
@@ -1633,14 +1633,14 @@ type APIRuntimeinfoFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c APIRuntimeinfoFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c APIRuntimeinfoFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c APIRuntimeinfoFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c APIRuntimeinfoFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // APISeriesFunc describes the behavior when the Series method of the parent
@@ -1750,14 +1750,14 @@ type APISeriesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c APISeriesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c APISeriesFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c APISeriesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c APISeriesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // APISnapshotFunc describes the behavior when the Snapshot method of the
@@ -1858,14 +1858,14 @@ type APISnapshotFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c APISnapshotFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c APISnapshotFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c APISnapshotFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c APISnapshotFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // APITSDBFunc describes the behavior when the TSDB method of the parent
@@ -1963,14 +1963,14 @@ type APITSDBFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c APITSDBFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c APITSDBFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c APITSDBFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c APITSDBFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // APITargetsFunc describes the behavior when the Targets method of the
@@ -2068,14 +2068,14 @@ type APITargetsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c APITargetsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c APITargetsFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c APITargetsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c APITargetsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // APITargetsMetadataFunc describes the behavior when the TargetsMetadata
@@ -2183,12 +2183,12 @@ type APITargetsMetadataFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c APITargetsMetadataFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c APITargetsMetadataFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c APITargetsMetadataFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c APITargetsMetadataFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }

--- a/docker-images/prometheus/cmd/prom-wrapper/siteconfig.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/siteconfig.go
@@ -139,7 +139,7 @@ func (c *SiteConfigSubscriber) Handler() http.Handler {
 				conf.NewSiteProblem("`observability`: unable to reach Alertmanager - please refer to the Prometheus logs for more details"))
 		}
 
-		b, err := json.Marshal(map[string]interface{}{
+		b, err := json.Marshal(map[string]any{
 			"problems": problems,
 		})
 		if err != nil {

--- a/enterprise/cmd/executor/internal/apiclient/baseclient.go
+++ b/enterprise/cmd/executor/internal/apiclient/baseclient.go
@@ -19,24 +19,24 @@ import (
 // The following is a minimal example of decorating the base client, making the
 // actual logic of the decorated client extremely lean:
 //
-//     type SprocketClient struct {
-//         *httpcli.BaseClient
+//	type SprocketClient struct {
+//	    *httpcli.BaseClient
 //
-//         baseURL *url.URL
-//     }
+//	    baseURL *url.URL
+//	}
 //
-//     func (c *SprocketClient) Fabricate(ctx context.Context(), spec SprocketSpec) (Sprocket, error) {
-//         url := c.baseURL.ResolveReference(&url.URL{Path: "/new"})
+//	func (c *SprocketClient) Fabricate(ctx context.Context(), spec SprocketSpec) (Sprocket, error) {
+//	    url := c.baseURL.ResolveReference(&url.URL{Path: "/new"})
 //
-//         req, err := httpcli.MakeJSONRequest("POST", url.String(), spec)
-//         if err != nil {
-//             return Sprocket{}, err
-//         }
+//	    req, err := httpcli.MakeJSONRequest("POST", url.String(), spec)
+//	    if err != nil {
+//	        return Sprocket{}, err
+//	    }
 //
-//         var s Sprocket
-//         err := c.client.DoAndDecode(ctx, req, &s)
-//         return s, err
-//     }
+//	    var s Sprocket
+//	    err := c.client.DoAndDecode(ctx, req, &s)
+//	    return s, err
+//	}
 type BaseClient struct {
 	httpClient *http.Client
 	options    BaseClientOptions
@@ -87,7 +87,7 @@ func (c *BaseClient) Do(ctx context.Context, req *http.Request) (hasContent bool
 // DoAndDecode performs the given HTTP request and unmarshals the response body into the
 // given interface pointer. If the response body was empty due to a 204 response, then a
 // false-valued flag is returned.
-func (c *BaseClient) DoAndDecode(ctx context.Context, req *http.Request, payload interface{}) (decoded bool, _ error) {
+func (c *BaseClient) DoAndDecode(ctx context.Context, req *http.Request, payload any) (decoded bool, _ error) {
 	hasContent, body, err := c.Do(ctx, req)
 	if err == nil && hasContent {
 		defer body.Close()
@@ -109,7 +109,7 @@ func (c *BaseClient) DoAndDrop(ctx context.Context, req *http.Request) error {
 
 // MakeJSONRequest creates an HTTP request with the given payload serialized as JSON. This
 // will also ensure that the proper content type header (which is necessary, not pedantic).
-func MakeJSONRequest(method string, url *url.URL, payload interface{}) (*http.Request, error) {
+func MakeJSONRequest(method string, url *url.URL, payload any) (*http.Request, error) {
 	contents, err := json.Marshal(payload)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/executor/internal/apiclient/client.go
+++ b/enterprise/cmd/executor/internal/apiclient/client.go
@@ -206,7 +206,7 @@ func (c *Client) Heartbeat(ctx context.Context, queueName string, jobIDs []int) 
 	return knownIDs, nil
 }
 
-func (c *Client) makeRequest(method, path string, payload interface{}) (*http.Request, error) {
+func (c *Client) makeRequest(method, path string, payload any) (*http.Request, error) {
 	u, err := makeURL(
 		c.options.EndpointOptions.URL,
 		c.options.EndpointOptions.Username,

--- a/enterprise/cmd/executor/internal/apiclient/client_test.go
+++ b/enterprise/cmd/executor/internal/apiclient/client_test.go
@@ -422,7 +422,7 @@ func testServer(t *testing.T, spec routeSpec) *httptest.Server {
 }
 
 func normalizeJSON(v []byte) string {
-	temp := map[string]interface{}{}
+	temp := map[string]any{}
 	_ = json.Unmarshal(v, &temp)
 	v, _ = json.Marshal(temp)
 	return string(v)

--- a/enterprise/cmd/executor/internal/command/mock_runner_test.go
+++ b/enterprise/cmd/executor/internal/command/mock_runner_test.go
@@ -147,12 +147,12 @@ type CommandRunnerRunCommandFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c CommandRunnerRunCommandFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c CommandRunnerRunCommandFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c CommandRunnerRunCommandFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c CommandRunnerRunCommandFuncCall) Results() []any {
+	return []any{c.Result0}
 }

--- a/enterprise/cmd/executor/internal/command/util.go
+++ b/enterprise/cmd/executor/internal/command/util.go
@@ -2,7 +2,7 @@ package command
 
 // flatten combines string values and (non-recursive) string slice values
 // into a single string slice.
-func flatten(values ...interface{}) []string {
+func flatten(values ...any) []string {
 	union := make([]string, 0, len(values))
 	for _, value := range values {
 		switch v := value.(type) {

--- a/enterprise/cmd/executor/internal/worker/handler.go
+++ b/enterprise/cmd/executor/internal/worker/handler.go
@@ -207,7 +207,7 @@ func scriptNameFromJobStep(job executor.Job, i int) string {
 }
 
 func createHoneyEvent(ctx context.Context, job executor.Job, err error, duration time.Duration) *libhoney.Event {
-	fields := map[string]interface{}{
+	fields := map[string]any{
 		"duration_ms":    duration.Milliseconds(),
 		"recordID":       job.RecordID(),
 		"repositoryName": job.RepositoryName,

--- a/enterprise/cmd/executor/internal/worker/mock_command_runner_test.go
+++ b/enterprise/cmd/executor/internal/worker/mock_command_runner_test.go
@@ -158,14 +158,14 @@ type RunnerRunFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c RunnerRunFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c RunnerRunFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c RunnerRunFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c RunnerRunFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // RunnerSetupFunc describes the behavior when the Setup method of the
@@ -266,14 +266,14 @@ type RunnerSetupFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c RunnerSetupFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c RunnerSetupFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c RunnerSetupFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c RunnerSetupFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // RunnerTeardownFunc describes the behavior when the Teardown method of the
@@ -368,12 +368,12 @@ type RunnerTeardownFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c RunnerTeardownFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c RunnerTeardownFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c RunnerTeardownFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c RunnerTeardownFuncCall) Results() []any {
+	return []any{c.Result0}
 }

--- a/enterprise/cmd/executor/internal/worker/mock_store_test.go
+++ b/enterprise/cmd/executor/internal/worker/mock_store_test.go
@@ -49,7 +49,7 @@ func NewMockStore() *MockStore {
 			},
 		},
 		DequeueFunc: &StoreDequeueFunc{
-			defaultHook: func(context.Context, string, interface{}) (workerutil.Record, bool, error) {
+			defaultHook: func(context.Context, string, any) (workerutil.Record, bool, error) {
 				return nil, false, nil
 			},
 		},
@@ -74,7 +74,7 @@ func NewMockStore() *MockStore {
 			},
 		},
 		QueuedCountFunc: &StoreQueuedCountFunc{
-			defaultHook: func(context.Context, interface{}) (int, error) {
+			defaultHook: func(context.Context, any) (int, error) {
 				return 0, nil
 			},
 		},
@@ -219,28 +219,28 @@ type StoreAddExecutionLogEntryFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreAddExecutionLogEntryFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c StoreAddExecutionLogEntryFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreAddExecutionLogEntryFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c StoreAddExecutionLogEntryFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // StoreDequeueFunc describes the behavior when the Dequeue method of the
 // parent MockStore instance is invoked.
 type StoreDequeueFunc struct {
-	defaultHook func(context.Context, string, interface{}) (workerutil.Record, bool, error)
-	hooks       []func(context.Context, string, interface{}) (workerutil.Record, bool, error)
+	defaultHook func(context.Context, string, any) (workerutil.Record, bool, error)
+	hooks       []func(context.Context, string, any) (workerutil.Record, bool, error)
 	history     []StoreDequeueFuncCall
 	mutex       sync.Mutex
 }
 
 // Dequeue delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockStore) Dequeue(v0 context.Context, v1 string, v2 interface{}) (workerutil.Record, bool, error) {
+func (m *MockStore) Dequeue(v0 context.Context, v1 string, v2 any) (workerutil.Record, bool, error) {
 	r0, r1, r2 := m.DequeueFunc.nextHook()(v0, v1, v2)
 	m.DequeueFunc.appendCall(StoreDequeueFuncCall{v0, v1, v2, r0, r1, r2})
 	return r0, r1, r2
@@ -248,7 +248,7 @@ func (m *MockStore) Dequeue(v0 context.Context, v1 string, v2 interface{}) (work
 
 // SetDefaultHook sets function that is called when the Dequeue method of
 // the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreDequeueFunc) SetDefaultHook(hook func(context.Context, string, interface{}) (workerutil.Record, bool, error)) {
+func (f *StoreDequeueFunc) SetDefaultHook(hook func(context.Context, string, any) (workerutil.Record, bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -256,7 +256,7 @@ func (f *StoreDequeueFunc) SetDefaultHook(hook func(context.Context, string, int
 // Dequeue method of the parent MockStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *StoreDequeueFunc) PushHook(hook func(context.Context, string, interface{}) (workerutil.Record, bool, error)) {
+func (f *StoreDequeueFunc) PushHook(hook func(context.Context, string, any) (workerutil.Record, bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -265,7 +265,7 @@ func (f *StoreDequeueFunc) PushHook(hook func(context.Context, string, interface
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *StoreDequeueFunc) SetDefaultReturn(r0 workerutil.Record, r1 bool, r2 error) {
-	f.SetDefaultHook(func(context.Context, string, interface{}) (workerutil.Record, bool, error) {
+	f.SetDefaultHook(func(context.Context, string, any) (workerutil.Record, bool, error) {
 		return r0, r1, r2
 	})
 }
@@ -273,12 +273,12 @@ func (f *StoreDequeueFunc) SetDefaultReturn(r0 workerutil.Record, r1 bool, r2 er
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *StoreDequeueFunc) PushReturn(r0 workerutil.Record, r1 bool, r2 error) {
-	f.PushHook(func(context.Context, string, interface{}) (workerutil.Record, bool, error) {
+	f.PushHook(func(context.Context, string, any) (workerutil.Record, bool, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *StoreDequeueFunc) nextHook() func(context.Context, string, interface{}) (workerutil.Record, bool, error) {
+func (f *StoreDequeueFunc) nextHook() func(context.Context, string, any) (workerutil.Record, bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -319,7 +319,7 @@ type StoreDequeueFuncCall struct {
 	Arg1 string
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 interface{}
+	Arg2 any
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 workerutil.Record
@@ -333,14 +333,14 @@ type StoreDequeueFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreDequeueFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c StoreDequeueFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreDequeueFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c StoreDequeueFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // StoreHeartbeatFunc describes the behavior when the Heartbeat method of
@@ -441,14 +441,14 @@ type StoreHeartbeatFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreHeartbeatFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c StoreHeartbeatFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreHeartbeatFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c StoreHeartbeatFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // StoreMarkCompleteFunc describes the behavior when the MarkComplete method
@@ -549,14 +549,14 @@ type StoreMarkCompleteFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreMarkCompleteFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c StoreMarkCompleteFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreMarkCompleteFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c StoreMarkCompleteFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // StoreMarkErroredFunc describes the behavior when the MarkErrored method
@@ -660,14 +660,14 @@ type StoreMarkErroredFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreMarkErroredFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c StoreMarkErroredFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreMarkErroredFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c StoreMarkErroredFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // StoreMarkFailedFunc describes the behavior when the MarkFailed method of
@@ -771,28 +771,28 @@ type StoreMarkFailedFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreMarkFailedFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c StoreMarkFailedFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreMarkFailedFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c StoreMarkFailedFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // StoreQueuedCountFunc describes the behavior when the QueuedCount method
 // of the parent MockStore instance is invoked.
 type StoreQueuedCountFunc struct {
-	defaultHook func(context.Context, interface{}) (int, error)
-	hooks       []func(context.Context, interface{}) (int, error)
+	defaultHook func(context.Context, any) (int, error)
+	hooks       []func(context.Context, any) (int, error)
 	history     []StoreQueuedCountFuncCall
 	mutex       sync.Mutex
 }
 
 // QueuedCount delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockStore) QueuedCount(v0 context.Context, v1 interface{}) (int, error) {
+func (m *MockStore) QueuedCount(v0 context.Context, v1 any) (int, error) {
 	r0, r1 := m.QueuedCountFunc.nextHook()(v0, v1)
 	m.QueuedCountFunc.appendCall(StoreQueuedCountFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -800,7 +800,7 @@ func (m *MockStore) QueuedCount(v0 context.Context, v1 interface{}) (int, error)
 
 // SetDefaultHook sets function that is called when the QueuedCount method
 // of the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreQueuedCountFunc) SetDefaultHook(hook func(context.Context, interface{}) (int, error)) {
+func (f *StoreQueuedCountFunc) SetDefaultHook(hook func(context.Context, any) (int, error)) {
 	f.defaultHook = hook
 }
 
@@ -808,7 +808,7 @@ func (f *StoreQueuedCountFunc) SetDefaultHook(hook func(context.Context, interfa
 // QueuedCount method of the parent MockStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *StoreQueuedCountFunc) PushHook(hook func(context.Context, interface{}) (int, error)) {
+func (f *StoreQueuedCountFunc) PushHook(hook func(context.Context, any) (int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -817,7 +817,7 @@ func (f *StoreQueuedCountFunc) PushHook(hook func(context.Context, interface{}) 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *StoreQueuedCountFunc) SetDefaultReturn(r0 int, r1 error) {
-	f.SetDefaultHook(func(context.Context, interface{}) (int, error) {
+	f.SetDefaultHook(func(context.Context, any) (int, error) {
 		return r0, r1
 	})
 }
@@ -825,12 +825,12 @@ func (f *StoreQueuedCountFunc) SetDefaultReturn(r0 int, r1 error) {
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *StoreQueuedCountFunc) PushReturn(r0 int, r1 error) {
-	f.PushHook(func(context.Context, interface{}) (int, error) {
+	f.PushHook(func(context.Context, any) (int, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreQueuedCountFunc) nextHook() func(context.Context, interface{}) (int, error) {
+func (f *StoreQueuedCountFunc) nextHook() func(context.Context, any) (int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -868,7 +868,7 @@ type StoreQueuedCountFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 interface{}
+	Arg1 any
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 int
@@ -879,14 +879,14 @@ type StoreQueuedCountFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreQueuedCountFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c StoreQueuedCountFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreQueuedCountFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c StoreQueuedCountFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // StoreUpdateExecutionLogEntryFunc describes the behavior when the
@@ -992,12 +992,12 @@ type StoreUpdateExecutionLogEntryFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreUpdateExecutionLogEntryFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c StoreUpdateExecutionLogEntryFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreUpdateExecutionLogEntryFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c StoreUpdateExecutionLogEntryFuncCall) Results() []any {
+	return []any{c.Result0}
 }

--- a/enterprise/cmd/executor/internal/worker/store.go
+++ b/enterprise/cmd/executor/internal/worker/store.go
@@ -26,11 +26,11 @@ type QueueStore interface {
 
 var _ workerutil.Store = &storeShim{}
 
-func (s *storeShim) QueuedCount(ctx context.Context, extraArguments interface{}) (int, error) {
+func (s *storeShim) QueuedCount(ctx context.Context, extraArguments any) (int, error) {
 	return 0, errors.New("unimplemented")
 }
 
-func (s *storeShim) Dequeue(ctx context.Context, workerHostname string, extraArguments interface{}) (workerutil.Record, bool, error) {
+func (s *storeShim) Dequeue(ctx context.Context, workerHostname string, extraArguments any) (workerutil.Record, bool, error) {
 	var job executor.Job
 	dequeued, err := s.queueStore.Dequeue(ctx, s.queueName, &job)
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/auth/saml/user.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/user.go
@@ -20,7 +20,7 @@ type authnResponseInfo struct {
 	spec                 extsvc.AccountSpec
 	email, displayName   string
 	unnormalizedUsername string
-	accountData          interface{}
+	accountData          any
 }
 
 func readAuthnResponse(p *provider, encodedResp string) (*authnResponseInfo, error) {

--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/errors.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/errors.go
@@ -10,6 +10,6 @@ func (e *ClientError) Error() string {
 	return e.err.Error()
 }
 
-func clientError(message string, vals ...interface{}) error {
+func clientError(message string, vals ...any) error {
 	return &ClientError{err: errors.Errorf(message, vals...)}
 }

--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/mock_iface_test.go
@@ -206,14 +206,14 @@ type DBStoreAddUploadPartFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreAddUploadPartFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c DBStoreAddUploadPartFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreAddUploadPartFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c DBStoreAddUploadPartFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // DBStoreDoneFunc describes the behavior when the Done method of the parent
@@ -308,14 +308,14 @@ type DBStoreDoneFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreDoneFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c DBStoreDoneFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreDoneFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c DBStoreDoneFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // DBStoreGetUploadByIDFunc describes the behavior when the GetUploadByID
@@ -420,14 +420,14 @@ type DBStoreGetUploadByIDFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreGetUploadByIDFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreGetUploadByIDFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreGetUploadByIDFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c DBStoreGetUploadByIDFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // DBStoreInsertUploadFunc describes the behavior when the InsertUpload
@@ -529,14 +529,14 @@ type DBStoreInsertUploadFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreInsertUploadFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreInsertUploadFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreInsertUploadFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreInsertUploadFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreMarkFailedFunc describes the behavior when the MarkFailed method
@@ -637,14 +637,14 @@ type DBStoreMarkFailedFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreMarkFailedFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c DBStoreMarkFailedFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreMarkFailedFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c DBStoreMarkFailedFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // DBStoreMarkQueuedFunc describes the behavior when the MarkQueued method
@@ -745,14 +745,14 @@ type DBStoreMarkQueuedFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreMarkQueuedFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c DBStoreMarkQueuedFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreMarkQueuedFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c DBStoreMarkQueuedFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // DBStoreTransactFunc describes the behavior when the Transact method of
@@ -850,12 +850,12 @@ type DBStoreTransactFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreTransactFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c DBStoreTransactFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreTransactFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreTransactFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }

--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/util.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/util.go
@@ -44,7 +44,7 @@ func copyAll(w http.ResponseWriter, r io.Reader) {
 
 // writeJSON writes the JSON-encoded payload to w and logs on write failure.
 // If there is an encoding error, then a 500-level status is written to w.
-func writeJSON(w http.ResponseWriter, payload interface{}) {
+func writeJSON(w http.ResponseWriter, payload any) {
 	data, err := json.Marshal(payload)
 	if err != nil {
 		log15.Error("Failed to serialize result", "error", err)

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/hunk_cache.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/hunk_cache.go
@@ -6,11 +6,11 @@ import "github.com/dgraph-io/ristretto"
 type HunkCache interface {
 	// Get returns the value (if any) and a boolean representing whether the value was
 	// found or not.
-	Get(key interface{}) (interface{}, bool)
+	Get(key any) (any, bool)
 
 	// Set attempts to add the key-value item to the cache with the given cost. If it
 	// returns false, then the value as dropped and the item isn't added to the cache.
-	Set(key, value interface{}, cost int64) bool
+	Set(key, value any, cost int64) bool
 }
 
 // NewHunkCache creates a data cache instance with the given maximum capacity.

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
@@ -365,14 +365,14 @@ type DBStoreCommitGraphMetadataFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreCommitGraphMetadataFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreCommitGraphMetadataFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreCommitGraphMetadataFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c DBStoreCommitGraphMetadataFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // DBStoreDefinitionDumpsFunc describes the behavior when the
@@ -474,14 +474,14 @@ type DBStoreDefinitionDumpsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreDefinitionDumpsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreDefinitionDumpsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreDefinitionDumpsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreDefinitionDumpsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreDeleteIndexByIDFunc describes the behavior when the
@@ -583,14 +583,14 @@ type DBStoreDeleteIndexByIDFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreDeleteIndexByIDFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreDeleteIndexByIDFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreDeleteIndexByIDFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreDeleteIndexByIDFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreDeleteUploadByIDFunc describes the behavior when the
@@ -692,14 +692,14 @@ type DBStoreDeleteUploadByIDFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreDeleteUploadByIDFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreDeleteUploadByIDFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreDeleteUploadByIDFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreDeleteUploadByIDFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreFindClosestDumpsFunc describes the behavior when the
@@ -813,14 +813,14 @@ type DBStoreFindClosestDumpsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreFindClosestDumpsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
+func (c DBStoreFindClosestDumpsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreFindClosestDumpsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreFindClosestDumpsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreFindClosestDumpsFromGraphFragmentFunc describes the behavior when
@@ -941,14 +941,14 @@ type DBStoreFindClosestDumpsFromGraphFragmentFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreFindClosestDumpsFromGraphFragmentFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
+func (c DBStoreFindClosestDumpsFromGraphFragmentFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreFindClosestDumpsFromGraphFragmentFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreFindClosestDumpsFromGraphFragmentFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreGetDumpsByIDsFunc describes the behavior when the GetDumpsByIDs
@@ -1050,14 +1050,14 @@ type DBStoreGetDumpsByIDsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreGetDumpsByIDsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreGetDumpsByIDsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreGetDumpsByIDsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreGetDumpsByIDsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreGetIndexByIDFunc describes the behavior when the GetIndexByID
@@ -1162,14 +1162,14 @@ type DBStoreGetIndexByIDFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreGetIndexByIDFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreGetIndexByIDFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreGetIndexByIDFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c DBStoreGetIndexByIDFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // DBStoreGetIndexConfigurationByRepositoryIDFunc describes the behavior
@@ -1279,14 +1279,14 @@ type DBStoreGetIndexConfigurationByRepositoryIDFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreGetIndexConfigurationByRepositoryIDFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreGetIndexConfigurationByRepositoryIDFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreGetIndexConfigurationByRepositoryIDFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c DBStoreGetIndexConfigurationByRepositoryIDFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // DBStoreGetIndexesFunc describes the behavior when the GetIndexes method
@@ -1390,14 +1390,14 @@ type DBStoreGetIndexesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreGetIndexesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreGetIndexesFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreGetIndexesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c DBStoreGetIndexesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // DBStoreGetIndexesByIDsFunc describes the behavior when the
@@ -1501,19 +1501,19 @@ type DBStoreGetIndexesByIDsFuncCall struct {
 // invocation. The variadic slice argument is flattened in this array such
 // that one positional argument and three variadic arguments would result in
 // a slice of four, not two.
-func (c DBStoreGetIndexesByIDsFuncCall) Args() []interface{} {
-	trailing := []interface{}{}
+func (c DBStoreGetIndexesByIDsFuncCall) Args() []any {
+	trailing := []any{}
 	for _, val := range c.Arg1 {
 		trailing = append(trailing, val)
 	}
 
-	return append([]interface{}{c.Arg0}, trailing...)
+	return append([]any{c.Arg0}, trailing...)
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreGetIndexesByIDsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreGetIndexesByIDsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreGetUploadByIDFunc describes the behavior when the GetUploadByID
@@ -1618,14 +1618,14 @@ type DBStoreGetUploadByIDFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreGetUploadByIDFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreGetUploadByIDFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreGetUploadByIDFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c DBStoreGetUploadByIDFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // DBStoreGetUploadsFunc describes the behavior when the GetUploads method
@@ -1729,14 +1729,14 @@ type DBStoreGetUploadsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreGetUploadsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreGetUploadsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreGetUploadsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c DBStoreGetUploadsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // DBStoreGetUploadsByIDsFunc describes the behavior when the
@@ -1840,19 +1840,19 @@ type DBStoreGetUploadsByIDsFuncCall struct {
 // invocation. The variadic slice argument is flattened in this array such
 // that one positional argument and three variadic arguments would result in
 // a slice of four, not two.
-func (c DBStoreGetUploadsByIDsFuncCall) Args() []interface{} {
-	trailing := []interface{}{}
+func (c DBStoreGetUploadsByIDsFuncCall) Args() []any {
+	trailing := []any{}
 	for _, val := range c.Arg1 {
 		trailing = append(trailing, val)
 	}
 
-	return append([]interface{}{c.Arg0}, trailing...)
+	return append([]any{c.Arg0}, trailing...)
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreGetUploadsByIDsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreGetUploadsByIDsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreHasCommitFunc describes the behavior when the HasCommit method of
@@ -1956,14 +1956,14 @@ type DBStoreHasCommitFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreHasCommitFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c DBStoreHasCommitFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreHasCommitFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreHasCommitFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreHasRepositoryFunc describes the behavior when the HasRepository
@@ -2065,14 +2065,14 @@ type DBStoreHasRepositoryFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreHasRepositoryFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreHasRepositoryFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreHasRepositoryFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreHasRepositoryFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreMarkRepositoryAsDirtyFunc describes the behavior when the
@@ -2172,14 +2172,14 @@ type DBStoreMarkRepositoryAsDirtyFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreMarkRepositoryAsDirtyFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreMarkRepositoryAsDirtyFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreMarkRepositoryAsDirtyFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c DBStoreMarkRepositoryAsDirtyFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // DBStoreReferenceIDsAndFiltersFunc describes the behavior when the
@@ -2298,14 +2298,14 @@ type DBStoreReferenceIDsAndFiltersFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreReferenceIDsAndFiltersFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
+func (c DBStoreReferenceIDsAndFiltersFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreReferenceIDsAndFiltersFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c DBStoreReferenceIDsAndFiltersFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // DBStoreRepoNameFunc describes the behavior when the RepoName method of
@@ -2406,14 +2406,14 @@ type DBStoreRepoNameFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreRepoNameFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreRepoNameFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreRepoNameFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreRepoNameFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreUpdateIndexConfigurationByRepositoryIDFunc describes the behavior
@@ -2520,14 +2520,14 @@ type DBStoreUpdateIndexConfigurationByRepositoryIDFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreUpdateIndexConfigurationByRepositoryIDFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c DBStoreUpdateIndexConfigurationByRepositoryIDFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreUpdateIndexConfigurationByRepositoryIDFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c DBStoreUpdateIndexConfigurationByRepositoryIDFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // MockEnqueuerDBStore is a mock implementation of the EnqueuerDBStore
@@ -2742,14 +2742,14 @@ type EnqueuerDBStoreDirtyRepositoriesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c EnqueuerDBStoreDirtyRepositoriesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c EnqueuerDBStoreDirtyRepositoriesFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c EnqueuerDBStoreDirtyRepositoriesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c EnqueuerDBStoreDirtyRepositoriesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // EnqueuerDBStoreDoneFunc describes the behavior when the Done method of
@@ -2845,14 +2845,14 @@ type EnqueuerDBStoreDoneFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c EnqueuerDBStoreDoneFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c EnqueuerDBStoreDoneFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c EnqueuerDBStoreDoneFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c EnqueuerDBStoreDoneFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // EnqueuerDBStoreGetIndexConfigurationByRepositoryIDFunc describes the
@@ -2963,14 +2963,14 @@ type EnqueuerDBStoreGetIndexConfigurationByRepositoryIDFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c EnqueuerDBStoreGetIndexConfigurationByRepositoryIDFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c EnqueuerDBStoreGetIndexConfigurationByRepositoryIDFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c EnqueuerDBStoreGetIndexConfigurationByRepositoryIDFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c EnqueuerDBStoreGetIndexConfigurationByRepositoryIDFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // EnqueuerDBStoreGetRepositoriesWithIndexConfigurationFunc describes the
@@ -3075,14 +3075,14 @@ type EnqueuerDBStoreGetRepositoriesWithIndexConfigurationFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c EnqueuerDBStoreGetRepositoriesWithIndexConfigurationFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c EnqueuerDBStoreGetRepositoriesWithIndexConfigurationFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c EnqueuerDBStoreGetRepositoriesWithIndexConfigurationFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c EnqueuerDBStoreGetRepositoriesWithIndexConfigurationFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // EnqueuerDBStoreHandleFunc describes the behavior when the Handle method
@@ -3175,14 +3175,14 @@ type EnqueuerDBStoreHandleFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c EnqueuerDBStoreHandleFuncCall) Args() []interface{} {
-	return []interface{}{}
+func (c EnqueuerDBStoreHandleFuncCall) Args() []any {
+	return []any{}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c EnqueuerDBStoreHandleFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c EnqueuerDBStoreHandleFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // EnqueuerDBStoreInsertIndexFunc describes the behavior when the
@@ -3284,14 +3284,14 @@ type EnqueuerDBStoreInsertIndexFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c EnqueuerDBStoreInsertIndexFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c EnqueuerDBStoreInsertIndexFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c EnqueuerDBStoreInsertIndexFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c EnqueuerDBStoreInsertIndexFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // EnqueuerDBStoreIsQueuedFunc describes the behavior when the IsQueued
@@ -3396,14 +3396,14 @@ type EnqueuerDBStoreIsQueuedFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c EnqueuerDBStoreIsQueuedFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c EnqueuerDBStoreIsQueuedFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c EnqueuerDBStoreIsQueuedFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c EnqueuerDBStoreIsQueuedFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // EnqueuerDBStoreTransactFunc describes the behavior when the Transact
@@ -3502,14 +3502,14 @@ type EnqueuerDBStoreTransactFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c EnqueuerDBStoreTransactFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c EnqueuerDBStoreTransactFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c EnqueuerDBStoreTransactFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c EnqueuerDBStoreTransactFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // MockEnqueuerGitserverClient is a mock implementation of the
@@ -3698,14 +3698,14 @@ type EnqueuerGitserverClientFileExistsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c EnqueuerGitserverClientFileExistsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c EnqueuerGitserverClientFileExistsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c EnqueuerGitserverClientFileExistsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c EnqueuerGitserverClientFileExistsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // EnqueuerGitserverClientHeadFunc describes the behavior when the Head
@@ -3810,14 +3810,14 @@ type EnqueuerGitserverClientHeadFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c EnqueuerGitserverClientHeadFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c EnqueuerGitserverClientHeadFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c EnqueuerGitserverClientHeadFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c EnqueuerGitserverClientHeadFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // EnqueuerGitserverClientListFilesFunc describes the behavior when the
@@ -3928,14 +3928,14 @@ type EnqueuerGitserverClientListFilesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c EnqueuerGitserverClientListFilesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c EnqueuerGitserverClientListFilesFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c EnqueuerGitserverClientListFilesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c EnqueuerGitserverClientListFilesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // EnqueuerGitserverClientRawContentsFunc describes the behavior when the
@@ -4046,14 +4046,14 @@ type EnqueuerGitserverClientRawContentsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c EnqueuerGitserverClientRawContentsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c EnqueuerGitserverClientRawContentsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c EnqueuerGitserverClientRawContentsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c EnqueuerGitserverClientRawContentsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // EnqueuerGitserverClientResolveRevisionFunc describes the behavior when
@@ -4162,14 +4162,14 @@ type EnqueuerGitserverClientResolveRevisionFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c EnqueuerGitserverClientResolveRevisionFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c EnqueuerGitserverClientResolveRevisionFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c EnqueuerGitserverClientResolveRevisionFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c EnqueuerGitserverClientResolveRevisionFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // MockGitserverClient is a mock implementation of the GitserverClient
@@ -4320,14 +4320,14 @@ type GitserverClientCommitExistsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitserverClientCommitExistsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c GitserverClientCommitExistsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitserverClientCommitExistsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c GitserverClientCommitExistsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // GitserverClientCommitGraphFunc describes the behavior when the
@@ -4432,14 +4432,14 @@ type GitserverClientCommitGraphFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitserverClientCommitGraphFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c GitserverClientCommitGraphFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitserverClientCommitGraphFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c GitserverClientCommitGraphFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // MockIndexEnqueuer is a mock implementation of the IndexEnqueuer interface
@@ -4587,14 +4587,14 @@ type IndexEnqueuerForceQueueIndexesForRepositoryFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c IndexEnqueuerForceQueueIndexesForRepositoryFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c IndexEnqueuerForceQueueIndexesForRepositoryFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c IndexEnqueuerForceQueueIndexesForRepositoryFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c IndexEnqueuerForceQueueIndexesForRepositoryFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // IndexEnqueuerInferIndexConfigurationFunc describes the behavior when the
@@ -4700,14 +4700,14 @@ type IndexEnqueuerInferIndexConfigurationFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c IndexEnqueuerInferIndexConfigurationFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c IndexEnqueuerInferIndexConfigurationFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c IndexEnqueuerInferIndexConfigurationFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c IndexEnqueuerInferIndexConfigurationFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // MockLSIFStore is a mock implementation of the LSIFStore interface (from
@@ -5000,14 +5000,14 @@ type LSIFStoreBulkMonikerResultsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreBulkMonikerResultsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
+func (c LSIFStoreBulkMonikerResultsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreBulkMonikerResultsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c LSIFStoreBulkMonikerResultsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // LSIFStoreDefinitionsFunc describes the behavior when the Definitions
@@ -5127,14 +5127,14 @@ type LSIFStoreDefinitionsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreDefinitionsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
+func (c LSIFStoreDefinitionsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreDefinitionsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c LSIFStoreDefinitionsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // LSIFStoreDiagnosticsFunc describes the behavior when the Diagnostics
@@ -5248,14 +5248,14 @@ type LSIFStoreDiagnosticsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreDiagnosticsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+func (c LSIFStoreDiagnosticsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreDiagnosticsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c LSIFStoreDiagnosticsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // LSIFStoreDocumentationAtPositionFunc describes the behavior when the
@@ -5369,14 +5369,14 @@ type LSIFStoreDocumentationAtPositionFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreDocumentationAtPositionFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+func (c LSIFStoreDocumentationAtPositionFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreDocumentationAtPositionFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c LSIFStoreDocumentationAtPositionFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // LSIFStoreDocumentationDefinitionsFunc describes the behavior when the
@@ -5493,14 +5493,14 @@ type LSIFStoreDocumentationDefinitionsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreDocumentationDefinitionsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+func (c LSIFStoreDocumentationDefinitionsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreDocumentationDefinitionsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c LSIFStoreDocumentationDefinitionsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // LSIFStoreDocumentationPageFunc describes the behavior when the
@@ -5605,14 +5605,14 @@ type LSIFStoreDocumentationPageFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreDocumentationPageFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c LSIFStoreDocumentationPageFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreDocumentationPageFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c LSIFStoreDocumentationPageFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // LSIFStoreDocumentationPathInfoFunc describes the behavior when the
@@ -5719,14 +5719,14 @@ type LSIFStoreDocumentationPathInfoFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreDocumentationPathInfoFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c LSIFStoreDocumentationPathInfoFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreDocumentationPathInfoFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c LSIFStoreDocumentationPathInfoFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // LSIFStoreDocumentationReferencesFunc describes the behavior when the
@@ -5843,14 +5843,14 @@ type LSIFStoreDocumentationReferencesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreDocumentationReferencesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+func (c LSIFStoreDocumentationReferencesFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreDocumentationReferencesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c LSIFStoreDocumentationReferencesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // LSIFStoreExistsFunc describes the behavior when the Exists method of the
@@ -5954,14 +5954,14 @@ type LSIFStoreExistsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreExistsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c LSIFStoreExistsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreExistsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c LSIFStoreExistsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // LSIFStoreHoverFunc describes the behavior when the Hover method of the
@@ -6077,14 +6077,14 @@ type LSIFStoreHoverFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreHoverFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+func (c LSIFStoreHoverFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreHoverFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2, c.Result3}
+func (c LSIFStoreHoverFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2, c.Result3}
 }
 
 // LSIFStoreMonikersByPositionFunc describes the behavior when the
@@ -6196,14 +6196,14 @@ type LSIFStoreMonikersByPositionFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreMonikersByPositionFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+func (c LSIFStoreMonikersByPositionFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreMonikersByPositionFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c LSIFStoreMonikersByPositionFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // LSIFStorePackageInformationFunc describes the behavior when the
@@ -6315,14 +6315,14 @@ type LSIFStorePackageInformationFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStorePackageInformationFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c LSIFStorePackageInformationFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStorePackageInformationFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c LSIFStorePackageInformationFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // LSIFStoreRangesFunc describes the behavior when the Ranges method of the
@@ -6432,14 +6432,14 @@ type LSIFStoreRangesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreRangesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+func (c LSIFStoreRangesFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreRangesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c LSIFStoreRangesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // LSIFStoreReferencesFunc describes the behavior when the References method
@@ -6558,14 +6558,14 @@ type LSIFStoreReferencesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreReferencesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
+func (c LSIFStoreReferencesFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreReferencesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c LSIFStoreReferencesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // MockRepoUpdaterClient is a mock implementation of the RepoUpdaterClient
@@ -6704,12 +6704,12 @@ type RepoUpdaterClientEnqueueRepoUpdateFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c RepoUpdaterClientEnqueueRepoUpdateFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c RepoUpdaterClientEnqueueRepoUpdateFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c RepoUpdaterClientEnqueueRepoUpdateFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c RepoUpdaterClientEnqueueRepoUpdateFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_position_adjuster_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_position_adjuster_test.go
@@ -173,14 +173,14 @@ type PositionAdjusterAdjustPathFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c PositionAdjusterAdjustPathFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c PositionAdjusterAdjustPathFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c PositionAdjusterAdjustPathFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c PositionAdjusterAdjustPathFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // PositionAdjusterAdjustPositionFunc describes the behavior when the
@@ -299,14 +299,14 @@ type PositionAdjusterAdjustPositionFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c PositionAdjusterAdjustPositionFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+func (c PositionAdjusterAdjustPositionFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c PositionAdjusterAdjustPositionFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2, c.Result3}
+func (c PositionAdjusterAdjustPositionFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2, c.Result3}
 }
 
 // PositionAdjusterAdjustRangeFunc describes the behavior when the
@@ -424,12 +424,12 @@ type PositionAdjusterAdjustRangeFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c PositionAdjusterAdjustRangeFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+func (c PositionAdjusterAdjustRangeFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c PositionAdjusterAdjustRangeFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2, c.Result3}
+func (c PositionAdjusterAdjustRangeFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2, c.Result3}
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_query.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_query.go
@@ -245,14 +245,14 @@ type QueryResolverDefinitionsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c QueryResolverDefinitionsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c QueryResolverDefinitionsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c QueryResolverDefinitionsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c QueryResolverDefinitionsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // QueryResolverDiagnosticsFunc describes the behavior when the Diagnostics
@@ -357,14 +357,14 @@ type QueryResolverDiagnosticsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c QueryResolverDiagnosticsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c QueryResolverDiagnosticsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c QueryResolverDiagnosticsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c QueryResolverDiagnosticsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // QueryResolverDocumentationFunc describes the behavior when the
@@ -469,14 +469,14 @@ type QueryResolverDocumentationFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c QueryResolverDocumentationFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c QueryResolverDocumentationFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c QueryResolverDocumentationFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c QueryResolverDocumentationFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // QueryResolverDocumentationDefinitionsFunc describes the behavior when the
@@ -582,14 +582,14 @@ type QueryResolverDocumentationDefinitionsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c QueryResolverDocumentationDefinitionsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c QueryResolverDocumentationDefinitionsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c QueryResolverDocumentationDefinitionsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c QueryResolverDocumentationDefinitionsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // QueryResolverDocumentationPageFunc describes the behavior when the
@@ -693,14 +693,14 @@ type QueryResolverDocumentationPageFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c QueryResolverDocumentationPageFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c QueryResolverDocumentationPageFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c QueryResolverDocumentationPageFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c QueryResolverDocumentationPageFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // QueryResolverDocumentationPathInfoFunc describes the behavior when the
@@ -805,14 +805,14 @@ type QueryResolverDocumentationPathInfoFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c QueryResolverDocumentationPathInfoFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c QueryResolverDocumentationPathInfoFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c QueryResolverDocumentationPathInfoFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c QueryResolverDocumentationPathInfoFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // QueryResolverDocumentationReferencesFunc describes the behavior when the
@@ -927,14 +927,14 @@ type QueryResolverDocumentationReferencesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c QueryResolverDocumentationReferencesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c QueryResolverDocumentationReferencesFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c QueryResolverDocumentationReferencesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c QueryResolverDocumentationReferencesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // QueryResolverHoverFunc describes the behavior when the Hover method of
@@ -1044,14 +1044,14 @@ type QueryResolverHoverFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c QueryResolverHoverFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c QueryResolverHoverFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c QueryResolverHoverFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2, c.Result3}
+func (c QueryResolverHoverFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2, c.Result3}
 }
 
 // QueryResolverRangesFunc describes the behavior when the Ranges method of
@@ -1155,14 +1155,14 @@ type QueryResolverRangesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c QueryResolverRangesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c QueryResolverRangesFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c QueryResolverRangesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c QueryResolverRangesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // QueryResolverReferencesFunc describes the behavior when the References
@@ -1276,12 +1276,12 @@ type QueryResolverReferencesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c QueryResolverReferencesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+func (c QueryResolverReferencesFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c QueryResolverReferencesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c QueryResolverReferencesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_resolver.go
@@ -275,14 +275,14 @@ type ResolverCommitGraphFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c ResolverCommitGraphFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c ResolverCommitGraphFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c ResolverCommitGraphFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c ResolverCommitGraphFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // ResolverDeleteIndexByIDFunc describes the behavior when the
@@ -381,14 +381,14 @@ type ResolverDeleteIndexByIDFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c ResolverDeleteIndexByIDFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c ResolverDeleteIndexByIDFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c ResolverDeleteIndexByIDFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c ResolverDeleteIndexByIDFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // ResolverDeleteUploadByIDFunc describes the behavior when the
@@ -487,14 +487,14 @@ type ResolverDeleteUploadByIDFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c ResolverDeleteUploadByIDFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c ResolverDeleteUploadByIDFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c ResolverDeleteUploadByIDFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c ResolverDeleteUploadByIDFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // ResolverGetIndexByIDFunc describes the behavior when the GetIndexByID
@@ -599,14 +599,14 @@ type ResolverGetIndexByIDFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c ResolverGetIndexByIDFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c ResolverGetIndexByIDFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c ResolverGetIndexByIDFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c ResolverGetIndexByIDFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // ResolverGetIndexesByIDsFunc describes the behavior when the
@@ -710,19 +710,19 @@ type ResolverGetIndexesByIDsFuncCall struct {
 // invocation. The variadic slice argument is flattened in this array such
 // that one positional argument and three variadic arguments would result in
 // a slice of four, not two.
-func (c ResolverGetIndexesByIDsFuncCall) Args() []interface{} {
-	trailing := []interface{}{}
+func (c ResolverGetIndexesByIDsFuncCall) Args() []any {
+	trailing := []any{}
 	for _, val := range c.Arg1 {
 		trailing = append(trailing, val)
 	}
 
-	return append([]interface{}{c.Arg0}, trailing...)
+	return append([]any{c.Arg0}, trailing...)
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c ResolverGetIndexesByIDsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c ResolverGetIndexesByIDsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // ResolverGetUploadByIDFunc describes the behavior when the GetUploadByID
@@ -827,14 +827,14 @@ type ResolverGetUploadByIDFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c ResolverGetUploadByIDFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c ResolverGetUploadByIDFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c ResolverGetUploadByIDFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c ResolverGetUploadByIDFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // ResolverGetUploadsByIDsFunc describes the behavior when the
@@ -938,19 +938,19 @@ type ResolverGetUploadsByIDsFuncCall struct {
 // invocation. The variadic slice argument is flattened in this array such
 // that one positional argument and three variadic arguments would result in
 // a slice of four, not two.
-func (c ResolverGetUploadsByIDsFuncCall) Args() []interface{} {
-	trailing := []interface{}{}
+func (c ResolverGetUploadsByIDsFuncCall) Args() []any {
+	trailing := []any{}
 	for _, val := range c.Arg1 {
 		trailing = append(trailing, val)
 	}
 
-	return append([]interface{}{c.Arg0}, trailing...)
+	return append([]any{c.Arg0}, trailing...)
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c ResolverGetUploadsByIDsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c ResolverGetUploadsByIDsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // ResolverIndexConfigurationFunc describes the behavior when the
@@ -1052,14 +1052,14 @@ type ResolverIndexConfigurationFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c ResolverIndexConfigurationFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c ResolverIndexConfigurationFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c ResolverIndexConfigurationFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c ResolverIndexConfigurationFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // ResolverIndexConnectionResolverFunc describes the behavior when the
@@ -1158,14 +1158,14 @@ type ResolverIndexConnectionResolverFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c ResolverIndexConnectionResolverFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c ResolverIndexConnectionResolverFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c ResolverIndexConnectionResolverFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c ResolverIndexConnectionResolverFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // ResolverQueryResolverFunc describes the behavior when the QueryResolver
@@ -1267,14 +1267,14 @@ type ResolverQueryResolverFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c ResolverQueryResolverFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c ResolverQueryResolverFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c ResolverQueryResolverFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c ResolverQueryResolverFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // ResolverQueueAutoIndexJobForRepoFunc describes the behavior when the
@@ -1376,14 +1376,14 @@ type ResolverQueueAutoIndexJobForRepoFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c ResolverQueueAutoIndexJobForRepoFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c ResolverQueueAutoIndexJobForRepoFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c ResolverQueueAutoIndexJobForRepoFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c ResolverQueueAutoIndexJobForRepoFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // ResolverUpdateIndexConfigurationByRepositoryIDFunc describes the behavior
@@ -1490,14 +1490,14 @@ type ResolverUpdateIndexConfigurationByRepositoryIDFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c ResolverUpdateIndexConfigurationByRepositoryIDFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c ResolverUpdateIndexConfigurationByRepositoryIDFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c ResolverUpdateIndexConfigurationByRepositoryIDFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c ResolverUpdateIndexConfigurationByRepositoryIDFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // ResolverUploadConnectionResolverFunc describes the behavior when the
@@ -1596,12 +1596,12 @@ type ResolverUploadConnectionResolverFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c ResolverUploadConnectionResolverFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c ResolverUploadConnectionResolverFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c ResolverUploadConnectionResolverFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c ResolverUploadConnectionResolverFuncCall) Results() []any {
+	return []any{c.Result0}
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/observability.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/observability.go
@@ -110,7 +110,7 @@ func lowSlowRequest(name string, duration time.Duration, err *error, observation
 }
 
 func createHoneyEvent(ctx context.Context, name string, observationArgs observation.Args, err *error, duration time.Duration) *libhoney.Event {
-	fields := map[string]interface{}{
+	fields := map[string]any{
 		"type":        name,
 		"duration_ms": duration.Milliseconds(),
 	}

--- a/enterprise/cmd/frontend/internal/executorqueue/handler/routes.go
+++ b/enterprise/cmd/frontend/internal/executorqueue/handler/routes.go
@@ -40,7 +40,7 @@ func SetupRoutes(queueOptionsMap map[string]QueueOptions, router *mux.Router) {
 func (h *handler) handleDequeue(w http.ResponseWriter, r *http.Request) {
 	var payload apiclient.DequeueRequest
 
-	h.wrapHandler(w, r, &payload, func() (int, interface{}, error) {
+	h.wrapHandler(w, r, &payload, func() (int, any, error) {
 		job, dequeued, err := h.dequeue(r.Context(), payload.ExecutorName, payload.ExecutorHostname)
 		if !dequeued {
 			return http.StatusNoContent, nil, err
@@ -54,7 +54,7 @@ func (h *handler) handleDequeue(w http.ResponseWriter, r *http.Request) {
 func (h *handler) handleAddExecutionLogEntry(w http.ResponseWriter, r *http.Request) {
 	var payload apiclient.AddExecutionLogEntryRequest
 
-	h.wrapHandler(w, r, &payload, func() (int, interface{}, error) {
+	h.wrapHandler(w, r, &payload, func() (int, any, error) {
 		id, err := h.addExecutionLogEntry(r.Context(), payload.ExecutorName, payload.JobID, payload.ExecutionLogEntry)
 		return http.StatusOK, id, err
 	})
@@ -64,7 +64,7 @@ func (h *handler) handleAddExecutionLogEntry(w http.ResponseWriter, r *http.Requ
 func (h *handler) handleUpdateExecutionLogEntry(w http.ResponseWriter, r *http.Request) {
 	var payload apiclient.UpdateExecutionLogEntryRequest
 
-	h.wrapHandler(w, r, &payload, func() (int, interface{}, error) {
+	h.wrapHandler(w, r, &payload, func() (int, any, error) {
 		err := h.updateExecutionLogEntry(r.Context(), payload.ExecutorName, payload.JobID, payload.EntryID, payload.ExecutionLogEntry)
 		return http.StatusNoContent, nil, err
 	})
@@ -74,7 +74,7 @@ func (h *handler) handleUpdateExecutionLogEntry(w http.ResponseWriter, r *http.R
 func (h *handler) handleMarkComplete(w http.ResponseWriter, r *http.Request) {
 	var payload apiclient.MarkCompleteRequest
 
-	h.wrapHandler(w, r, &payload, func() (int, interface{}, error) {
+	h.wrapHandler(w, r, &payload, func() (int, any, error) {
 		err := h.markComplete(r.Context(), payload.ExecutorName, payload.JobID)
 		if err == ErrUnknownJob {
 			return http.StatusNotFound, nil, nil
@@ -88,7 +88,7 @@ func (h *handler) handleMarkComplete(w http.ResponseWriter, r *http.Request) {
 func (h *handler) handleMarkErrored(w http.ResponseWriter, r *http.Request) {
 	var payload apiclient.MarkErroredRequest
 
-	h.wrapHandler(w, r, &payload, func() (int, interface{}, error) {
+	h.wrapHandler(w, r, &payload, func() (int, any, error) {
 		err := h.markErrored(r.Context(), payload.ExecutorName, payload.JobID, payload.ErrorMessage)
 		if err == ErrUnknownJob {
 			return http.StatusNotFound, nil, nil
@@ -102,7 +102,7 @@ func (h *handler) handleMarkErrored(w http.ResponseWriter, r *http.Request) {
 func (h *handler) handleMarkFailed(w http.ResponseWriter, r *http.Request) {
 	var payload apiclient.MarkErroredRequest
 
-	h.wrapHandler(w, r, &payload, func() (int, interface{}, error) {
+	h.wrapHandler(w, r, &payload, func() (int, any, error) {
 		err := h.markFailed(r.Context(), payload.ExecutorName, payload.JobID, payload.ErrorMessage)
 		if err == ErrUnknownJob {
 			return http.StatusNotFound, nil, nil
@@ -116,7 +116,7 @@ func (h *handler) handleMarkFailed(w http.ResponseWriter, r *http.Request) {
 func (h *handler) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	var payload apiclient.HeartbeatRequest
 
-	h.wrapHandler(w, r, &payload, func() (int, interface{}, error) {
+	h.wrapHandler(w, r, &payload, func() (int, any, error) {
 		unknownIDs, err := h.heartbeat(r.Context(), payload.ExecutorName, payload.JobIDs)
 		return http.StatusOK, unknownIDs, err
 	})
@@ -132,7 +132,7 @@ type errorResponse struct {
 // is returned. Otherwise, the response status will match the status code value returned from the
 // handler, and the payload value returned from the handler is encoded and written to the
 // response body.
-func (h *handler) wrapHandler(w http.ResponseWriter, r *http.Request, payload interface{}, handler func() (int, interface{}, error)) {
+func (h *handler) wrapHandler(w http.ResponseWriter, r *http.Request, payload any, handler func() (int, any, error)) {
 	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 		http.Error(w, fmt.Sprintf("Failed to unmarshal payload: %s", err.Error()), http.StatusBadRequest)
 		return

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users_test.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users_test.go
@@ -152,7 +152,7 @@ func TestEnforcement_AfterCreateUser(t *testing.T) {
 
 			calledExecContext := false
 			db := &fakeDB{
-				execContext: func(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+				execContext: func(ctx context.Context, query string, args ...any) (sql.Result, error) {
 					calledExecContext = true
 					return nil, nil
 				},
@@ -178,18 +178,18 @@ func TestEnforcement_AfterCreateUser(t *testing.T) {
 }
 
 type fakeDB struct {
-	execContext func(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+	execContext func(ctx context.Context, query string, args ...any) (sql.Result, error)
 }
 
-func (db *fakeDB) QueryContext(ctx context.Context, q string, args ...interface{}) (*sql.Rows, error) {
+func (db *fakeDB) QueryContext(ctx context.Context, q string, args ...any) (*sql.Rows, error) {
 	panic("implement me")
 }
 
-func (db *fakeDB) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+func (db *fakeDB) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
 	return db.execContext(ctx, query, args...)
 }
 
-func (db *fakeDB) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+func (db *fakeDB) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
 	panic("implement me")
 }
 

--- a/enterprise/cmd/frontend/internal/registry/allow.go
+++ b/enterprise/cmd/frontend/internal/registry/allow.go
@@ -30,7 +30,7 @@ func init() {
 			return extensions
 		}
 
-		allow := make(map[string]interface{})
+		allow := make(map[string]any)
 		for _, id := range allowedExtensions {
 			allow[id] = struct{}{}
 		}

--- a/enterprise/cmd/frontend/internal/registry/extension_manifest.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_manifest.go
@@ -20,7 +20,7 @@ import (
 //
 // TODO(sqs): Also validate it against the JSON Schema.
 func validateExtensionManifest(text string) error {
-	var o interface{}
+	var o any
 	return jsonc.Unmarshal(text, &o)
 }
 
@@ -80,7 +80,7 @@ func getLatestForBatch(ctx context.Context, vs []*dbExtension) (map[int32]*dbRel
 // the date that the release was published.
 func prepReleaseManifest(extensionID string, release *dbRelease) error {
 	// Add URL to bundle if necessary.
-	o := make(map[string]interface{})
+	o := make(map[string]any)
 	if err := json.Unmarshal([]byte(release.Manifest), &o); err != nil {
 		return err
 	}

--- a/enterprise/cmd/frontend/internal/registry/extension_manifest_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_manifest_test.go
@@ -55,7 +55,7 @@ func TestGetExtensionManifestWithBundleURL(t *testing.T) {
 }
 
 func jsonDeepEqual(a, b string) bool {
-	var va, vb interface{}
+	var va, vb any
 	if err := json.Unmarshal([]byte(a), &va); err != nil {
 		panic(err)
 	}

--- a/enterprise/cmd/frontend/internal/registry/extensions_db.go
+++ b/enterprise/cmd/frontend/internal/registry/extensions_db.go
@@ -58,7 +58,7 @@ type dbExtensions struct{}
 
 // extensionNotFoundError occurs when an extension is not found in the extension registry.
 type extensionNotFoundError struct {
-	args []interface{}
+	args []any
 }
 
 // NotFound implements errcode.NotFounder.
@@ -116,7 +116,7 @@ func (s dbExtensions) GetByID(ctx context.Context, id int32) (*dbExtension, erro
 		return nil, err
 	}
 	if len(results) == 0 {
-		return nil, extensionNotFoundError{[]interface{}{id}}
+		return nil, extensionNotFoundError{[]any{id}}
 	}
 	return results[0], nil
 }
@@ -134,7 +134,7 @@ func (s dbExtensions) GetByUUID(ctx context.Context, uuid string) (*dbExtension,
 		return nil, err
 	}
 	if len(results) == 0 {
-		return nil, extensionNotFoundError{[]interface{}{uuid}}
+		return nil, extensionNotFoundError{[]any{uuid}}
 	}
 	return results[0], nil
 }
@@ -163,7 +163,7 @@ func (s dbExtensions) GetByExtensionID(ctx context.Context, extensionID string) 
 	// (https://github.com/sourcegraph/sourcegraph/issues/12068).
 	parts := strings.SplitN(extensionID, "/", 2)
 	if len(parts) < 2 {
-		return nil, extensionNotFoundError{[]interface{}{fmt.Sprintf("extensionID %q", extensionID)}}
+		return nil, extensionNotFoundError{[]any{fmt.Sprintf("extensionID %q", extensionID)}}
 	}
 	publisherName := parts[0]
 	extensionName := parts[1]
@@ -176,7 +176,7 @@ func (s dbExtensions) GetByExtensionID(ctx context.Context, extensionID string) 
 		return nil, err
 	}
 	if len(results) == 0 {
-		return nil, extensionNotFoundError{[]interface{}{fmt.Sprintf("extensionID %q", extensionID)}}
+		return nil, extensionNotFoundError{[]any{fmt.Sprintf("extensionID %q", extensionID)}}
 	}
 	return results[0], nil
 }
@@ -386,7 +386,7 @@ func (dbExtensions) Update(ctx context.Context, id int32, name *string) error {
 		return err
 	}
 	if nrows == 0 {
-		return extensionNotFoundError{[]interface{}{id}}
+		return extensionNotFoundError{[]any{id}}
 	}
 	return nil
 }
@@ -406,7 +406,7 @@ func (dbExtensions) Delete(ctx context.Context, id int32) error {
 		return err
 	}
 	if nrows == 0 {
-		return extensionNotFoundError{[]interface{}{id}}
+		return extensionNotFoundError{[]any{id}}
 	}
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/registry/extensions_db_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extensions_db_test.go
@@ -488,7 +488,7 @@ func TestFeaturedExtensions(t *testing.T) {
 	}
 }
 
-func asJSON(t *testing.T, v interface{}) string {
+func asJSON(t *testing.T, v any) string {
 	b, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		t.Fatal(err)

--- a/enterprise/cmd/frontend/internal/registry/http_api.go
+++ b/enterprise/cmd/frontend/internal/registry/http_api.go
@@ -186,7 +186,7 @@ func handleRegistry(w http.ResponseWriter, r *http.Request) (err error) {
 	}
 
 	const extensionsPath = "/registry/extensions"
-	var result interface{}
+	var result any
 	switch {
 	case urlPath == extensionsPath:
 		operation = "list"

--- a/enterprise/cmd/frontend/internal/registry/publishers_db.go
+++ b/enterprise/cmd/frontend/internal/registry/publishers_db.go
@@ -25,7 +25,7 @@ func (p dbPublisher) IsZero() bool { return p == dbPublisher{} }
 
 // publisherNotFoundError occurs when a registry extension publisher is not found.
 type publisherNotFoundError struct {
-	args []interface{}
+	args []any
 }
 
 // NotFound implements errcode.NotFounder.
@@ -126,7 +126,7 @@ SELECT user_id, org_id, non_canonical_name FROM publishers ORDER BY user_id NULL
 	err := dbconn.Global.QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&userID, &orgID, &p.NonCanonicalName)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return nil, &publisherNotFoundError{[]interface{}{"name", name}}
+			return nil, &publisherNotFoundError{[]any{"name", name}}
 		}
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/registry/releases_db.go
+++ b/enterprise/cmd/frontend/internal/registry/releases_db.go
@@ -31,7 +31,7 @@ type dbReleases struct{}
 // releaseNotFoundError occurs when an extension release is not found in the
 // extension registry.
 type releaseNotFoundError struct {
-	args []interface{}
+	args []any
 }
 
 // NotFound implements errcode.NotFounder.
@@ -84,7 +84,7 @@ LIMIT 1`, includeArtifacts, includeArtifacts, registryExtensionID, releaseTag)
 	err := dbconn.Global.QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&r.ID, &r.RegistryExtensionID, &r.CreatorUserID, &r.ReleaseVersion, &r.ReleaseTag, &r.Manifest, &r.Bundle, &r.SourceMap, &r.CreatedAt)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return nil, releaseNotFoundError{[]interface{}{fmt.Sprintf("latest for registry extension ID %d tag %q", registryExtensionID, releaseTag)}}
+			return nil, releaseNotFoundError{[]any{fmt.Sprintf("latest for registry extension ID %d tag %q", registryExtensionID, releaseTag)}}
 		}
 		return nil, err
 	}
@@ -148,12 +148,12 @@ FROM registry_extension_releases
 WHERE id=%d AND deleted_at IS NULL`, id)
 	if err := dbconn.Global.QueryRowContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&bundle, &sourcemap); err != nil {
 		if err == sql.ErrNoRows {
-			return nil, nil, releaseNotFoundError{[]interface{}{fmt.Sprintf("registry extension release %d", id)}}
+			return nil, nil, releaseNotFoundError{[]any{fmt.Sprintf("registry extension release %d", id)}}
 		}
 		return nil, nil, err
 	}
 	if bundle == nil {
-		return nil, nil, releaseNotFoundError{[]interface{}{fmt.Sprintf("no bundle for registry extension release %d", id)}}
+		return nil, nil, releaseNotFoundError{[]any{fmt.Sprintf("no bundle for registry extension release %d", id)}}
 	}
 	return bundle, sourcemap, nil
 }

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
@@ -46,7 +46,7 @@ func (h *handler) Handle(ctx context.Context, record workerutil.Record) error {
 	return err
 }
 
-func (h *handler) PreDequeue(ctx context.Context) (bool, interface{}, error) {
+func (h *handler) PreDequeue(ctx context.Context) (bool, any, error) {
 	if !h.enableBudget {
 		return true, nil, nil
 	}
@@ -280,7 +280,7 @@ func isUniqueConstraintViolation(err error) bool {
 }
 
 func createHoneyEvent(ctx context.Context, upload store.Upload, err error, duration time.Duration) *libhoney.Event {
-	fields := map[string]interface{}{
+	fields := map[string]any{
 		"duration_ms":    duration.Milliseconds(),
 		"uploadID":       upload.ID,
 		"repositoryID":   upload.RepositoryID,

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/mock_iface_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/mock_iface_test.go
@@ -262,14 +262,14 @@ type DBStoreDeleteOverlappingDumpsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreDeleteOverlappingDumpsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+func (c DBStoreDeleteOverlappingDumpsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreDeleteOverlappingDumpsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c DBStoreDeleteOverlappingDumpsFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // DBStoreDoneFunc describes the behavior when the Done method of the parent
@@ -364,14 +364,14 @@ type DBStoreDoneFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreDoneFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c DBStoreDoneFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreDoneFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c DBStoreDoneFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // DBStoreHandleFunc describes the behavior when the Handle method of the
@@ -463,14 +463,14 @@ type DBStoreHandleFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreHandleFuncCall) Args() []interface{} {
-	return []interface{}{}
+func (c DBStoreHandleFuncCall) Args() []any {
+	return []any{}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreHandleFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c DBStoreHandleFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // DBStoreInsertDependencyIndexingJobFunc describes the behavior when the
@@ -575,14 +575,14 @@ type DBStoreInsertDependencyIndexingJobFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreInsertDependencyIndexingJobFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreInsertDependencyIndexingJobFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreInsertDependencyIndexingJobFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreInsertDependencyIndexingJobFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreMarkRepositoryAsDirtyFunc describes the behavior when the
@@ -682,14 +682,14 @@ type DBStoreMarkRepositoryAsDirtyFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreMarkRepositoryAsDirtyFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreMarkRepositoryAsDirtyFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreMarkRepositoryAsDirtyFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c DBStoreMarkRepositoryAsDirtyFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // DBStoreRepoNameFunc describes the behavior when the RepoName method of
@@ -790,14 +790,14 @@ type DBStoreRepoNameFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreRepoNameFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreRepoNameFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreRepoNameFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreRepoNameFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreTransactFunc describes the behavior when the Transact method of
@@ -895,14 +895,14 @@ type DBStoreTransactFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreTransactFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c DBStoreTransactFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreTransactFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreTransactFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreUpdateCommitedAtFunc describes the behavior when the
@@ -1004,14 +1004,14 @@ type DBStoreUpdateCommitedAtFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreUpdateCommitedAtFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c DBStoreUpdateCommitedAtFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreUpdateCommitedAtFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c DBStoreUpdateCommitedAtFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // DBStoreUpdatePackageReferencesFunc describes the behavior when the
@@ -1115,14 +1115,14 @@ type DBStoreUpdatePackageReferencesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreUpdatePackageReferencesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c DBStoreUpdatePackageReferencesFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreUpdatePackageReferencesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c DBStoreUpdatePackageReferencesFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // DBStoreUpdatePackagesFunc describes the behavior when the UpdatePackages
@@ -1224,14 +1224,14 @@ type DBStoreUpdatePackagesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreUpdatePackagesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c DBStoreUpdatePackagesFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreUpdatePackagesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c DBStoreUpdatePackagesFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // DBStoreWithFunc describes the behavior when the With method of the parent
@@ -1326,14 +1326,14 @@ type DBStoreWithFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreWithFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c DBStoreWithFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreWithFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c DBStoreWithFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // MockGitserverClient is a mock implementation of the GitserverClient
@@ -1494,14 +1494,14 @@ type GitserverClientCommitDateFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitserverClientCommitDateFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c GitserverClientCommitDateFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitserverClientCommitDateFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c GitserverClientCommitDateFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // GitserverClientDirectoryChildrenFunc describes the behavior when the
@@ -1612,14 +1612,14 @@ type GitserverClientDirectoryChildrenFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitserverClientDirectoryChildrenFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c GitserverClientDirectoryChildrenFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitserverClientDirectoryChildrenFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c GitserverClientDirectoryChildrenFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // GitserverClientResolveRevisionFunc describes the behavior when the
@@ -1726,14 +1726,14 @@ type GitserverClientResolveRevisionFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitserverClientResolveRevisionFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c GitserverClientResolveRevisionFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitserverClientResolveRevisionFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c GitserverClientResolveRevisionFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // MockLSIFStore is a mock implementation of the LSIFStore interface (from
@@ -1961,14 +1961,14 @@ type LSIFStoreDoneFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreDoneFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c LSIFStoreDoneFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreDoneFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c LSIFStoreDoneFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // LSIFStoreTransactFunc describes the behavior when the Transact method of
@@ -2066,14 +2066,14 @@ type LSIFStoreTransactFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreTransactFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c LSIFStoreTransactFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreTransactFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c LSIFStoreTransactFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // LSIFStoreWriteDefinitionsFunc describes the behavior when the
@@ -2175,14 +2175,14 @@ type LSIFStoreWriteDefinitionsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreWriteDefinitionsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c LSIFStoreWriteDefinitionsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreWriteDefinitionsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c LSIFStoreWriteDefinitionsFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // LSIFStoreWriteDocumentationMappingsFunc describes the behavior when the
@@ -2287,14 +2287,14 @@ type LSIFStoreWriteDocumentationMappingsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreWriteDocumentationMappingsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c LSIFStoreWriteDocumentationMappingsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreWriteDocumentationMappingsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c LSIFStoreWriteDocumentationMappingsFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // LSIFStoreWriteDocumentationPagesFunc describes the behavior when the
@@ -2399,14 +2399,14 @@ type LSIFStoreWriteDocumentationPagesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreWriteDocumentationPagesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c LSIFStoreWriteDocumentationPagesFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreWriteDocumentationPagesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c LSIFStoreWriteDocumentationPagesFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // LSIFStoreWriteDocumentationPathInfoFunc describes the behavior when the
@@ -2511,14 +2511,14 @@ type LSIFStoreWriteDocumentationPathInfoFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreWriteDocumentationPathInfoFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c LSIFStoreWriteDocumentationPathInfoFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreWriteDocumentationPathInfoFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c LSIFStoreWriteDocumentationPathInfoFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // LSIFStoreWriteDocumentsFunc describes the behavior when the
@@ -2620,14 +2620,14 @@ type LSIFStoreWriteDocumentsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreWriteDocumentsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c LSIFStoreWriteDocumentsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreWriteDocumentsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c LSIFStoreWriteDocumentsFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // LSIFStoreWriteMetaFunc describes the behavior when the WriteMeta method
@@ -2728,14 +2728,14 @@ type LSIFStoreWriteMetaFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreWriteMetaFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c LSIFStoreWriteMetaFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreWriteMetaFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c LSIFStoreWriteMetaFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // LSIFStoreWriteReferencesFunc describes the behavior when the
@@ -2837,14 +2837,14 @@ type LSIFStoreWriteReferencesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreWriteReferencesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c LSIFStoreWriteReferencesFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreWriteReferencesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c LSIFStoreWriteReferencesFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // LSIFStoreWriteResultChunksFunc describes the behavior when the
@@ -2946,12 +2946,12 @@ type LSIFStoreWriteResultChunksFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LSIFStoreWriteResultChunksFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c LSIFStoreWriteResultChunksFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreWriteResultChunksFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c LSIFStoreWriteResultChunksFuncCall) Results() []any {
+	return []any{c.Result0}
 }

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/mock_worker_store_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/mock_worker_store_test.go
@@ -264,14 +264,14 @@ type WorkerStoreAddExecutionLogEntryFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c WorkerStoreAddExecutionLogEntryFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c WorkerStoreAddExecutionLogEntryFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c WorkerStoreAddExecutionLogEntryFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c WorkerStoreAddExecutionLogEntryFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // WorkerStoreDequeueFunc describes the behavior when the Dequeue method of
@@ -379,14 +379,14 @@ type WorkerStoreDequeueFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c WorkerStoreDequeueFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c WorkerStoreDequeueFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c WorkerStoreDequeueFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c WorkerStoreDequeueFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // WorkerStoreHandleFunc describes the behavior when the Handle method of
@@ -478,14 +478,14 @@ type WorkerStoreHandleFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c WorkerStoreHandleFuncCall) Args() []interface{} {
-	return []interface{}{}
+func (c WorkerStoreHandleFuncCall) Args() []any {
+	return []any{}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c WorkerStoreHandleFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c WorkerStoreHandleFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // WorkerStoreHeartbeatFunc describes the behavior when the Heartbeat method
@@ -590,14 +590,14 @@ type WorkerStoreHeartbeatFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c WorkerStoreHeartbeatFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c WorkerStoreHeartbeatFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c WorkerStoreHeartbeatFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c WorkerStoreHeartbeatFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // WorkerStoreMarkCompleteFunc describes the behavior when the MarkComplete
@@ -702,14 +702,14 @@ type WorkerStoreMarkCompleteFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c WorkerStoreMarkCompleteFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c WorkerStoreMarkCompleteFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c WorkerStoreMarkCompleteFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c WorkerStoreMarkCompleteFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // WorkerStoreMarkErroredFunc describes the behavior when the MarkErrored
@@ -817,14 +817,14 @@ type WorkerStoreMarkErroredFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c WorkerStoreMarkErroredFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c WorkerStoreMarkErroredFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c WorkerStoreMarkErroredFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c WorkerStoreMarkErroredFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // WorkerStoreMarkFailedFunc describes the behavior when the MarkFailed
@@ -932,14 +932,14 @@ type WorkerStoreMarkFailedFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c WorkerStoreMarkFailedFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c WorkerStoreMarkFailedFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c WorkerStoreMarkFailedFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c WorkerStoreMarkFailedFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // WorkerStoreQueuedCountFunc describes the behavior when the QueuedCount
@@ -1041,14 +1041,14 @@ type WorkerStoreQueuedCountFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c WorkerStoreQueuedCountFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c WorkerStoreQueuedCountFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c WorkerStoreQueuedCountFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c WorkerStoreQueuedCountFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // WorkerStoreRequeueFunc describes the behavior when the Requeue method of
@@ -1150,14 +1150,14 @@ type WorkerStoreRequeueFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c WorkerStoreRequeueFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c WorkerStoreRequeueFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c WorkerStoreRequeueFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c WorkerStoreRequeueFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // WorkerStoreResetStalledFunc describes the behavior when the ResetStalled
@@ -1259,14 +1259,14 @@ type WorkerStoreResetStalledFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c WorkerStoreResetStalledFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c WorkerStoreResetStalledFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c WorkerStoreResetStalledFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c WorkerStoreResetStalledFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // WorkerStoreUpdateExecutionLogEntryFunc describes the behavior when the
@@ -1377,12 +1377,12 @@ type WorkerStoreUpdateExecutionLogEntryFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c WorkerStoreUpdateExecutionLogEntryFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+func (c WorkerStoreUpdateExecutionLogEntryFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c WorkerStoreUpdateExecutionLogEntryFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c WorkerStoreUpdateExecutionLogEntryFuncCall) Results() []any {
+	return []any{c.Result0}
 }

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -264,7 +264,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 
 	byURN := s.providersByURNs()
 
-	var accountsOrServices []interface{}
+	var accountsOrServices []any
 	for i := range accts {
 		accountsOrServices = append(accountsOrServices, accts[i])
 	}
@@ -770,10 +770,10 @@ type scheduledRepo struct {
 }
 
 // schedule computes schedule four lists in the following order:
-//   1. Users with no permissions, because they can't do anything meaningful (e.g. not able to search).
-//   2. Private repositories with no permissions, because those can't be viewed by anyone except site admins.
-//   3. Rolling updating user permissions over time from oldest ones.
-//   4. Rolling updating repository permissions over time from oldest ones.
+//  1. Users with no permissions, because they can't do anything meaningful (e.g. not able to search).
+//  2. Private repositories with no permissions, because those can't be viewed by anyone except site admins.
+//  3. Rolling updating user permissions over time from oldest ones.
+//  4. Rolling updating repository permissions over time from oldest ones.
 func (s *PermsSyncer) schedule(ctx context.Context) (*schedule, error) {
 	schedule := new(schedule)
 
@@ -861,7 +861,7 @@ func (s *PermsSyncer) runSchedule(ctx context.Context) {
 }
 
 // DebugDump returns the state of the permissions syncer for debugging.
-func (s *PermsSyncer) DebugDump() interface{} {
+func (s *PermsSyncer) DebugDump() any {
 	type requestInfo struct {
 		Meta     *requestMeta
 		Acquired bool

--- a/enterprise/cmd/repo-updater/internal/authz/request_queue.go
+++ b/enterprise/cmd/repo-updater/internal/authz/request_queue.go
@@ -227,7 +227,7 @@ func (q *requestQueue) Swap(i, j int) {
 	q.heap[j].index = j
 }
 
-func (q *requestQueue) Push(x interface{}) {
+func (q *requestQueue) Push(x any) {
 	n := len(q.heap)
 	request := x.(*syncRequest)
 	request.index = n
@@ -240,7 +240,7 @@ func (q *requestQueue) Push(x interface{}) {
 	q.index[key] = request
 }
 
-func (q *requestQueue) Pop() interface{} {
+func (q *requestQueue) Pop() any {
 	n := len(q.heap)
 	request := q.heap[n-1]
 	request.index = -1 // for safety

--- a/enterprise/cmd/worker/internal/codeintel/codeinteldb.go
+++ b/enterprise/cmd/worker/internal/codeintel/codeinteldb.go
@@ -20,7 +20,7 @@ func InitCodeIntelDatabase() (*sql.DB, error) {
 	return conn.(*sql.DB), err
 }
 
-var initCodeIntelDatabaseMemo = shared.NewMemoizedConstructor(func() (interface{}, error) {
+var initCodeIntelDatabaseMemo = shared.NewMemoizedConstructor(func() (any, error) {
 	postgresDSN := shared.WatchServiceConnectionValue(func(serviceConnections conftypes.ServiceConnections) string {
 		return serviceConnections.CodeIntelPostgresDSN
 	})

--- a/enterprise/cmd/worker/internal/codeintel/commitgraph/mock_iface_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/commitgraph/mock_iface_test.go
@@ -181,14 +181,14 @@ type DBStoreCalculateVisibleUploadsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreCalculateVisibleUploadsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6, c.Arg7}
+func (c DBStoreCalculateVisibleUploadsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5, c.Arg6, c.Arg7}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreCalculateVisibleUploadsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c DBStoreCalculateVisibleUploadsFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // DBStoreDirtyRepositoriesFunc describes the behavior when the
@@ -287,14 +287,14 @@ type DBStoreDirtyRepositoriesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreDirtyRepositoriesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c DBStoreDirtyRepositoriesFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreDirtyRepositoriesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreDirtyRepositoriesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreGetOldestCommitDateFunc describes the behavior when the
@@ -399,14 +399,14 @@ type DBStoreGetOldestCommitDateFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreGetOldestCommitDateFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreGetOldestCommitDateFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreGetOldestCommitDateFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c DBStoreGetOldestCommitDateFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // MockGitserverClient is a mock implementation of the GitserverClient
@@ -556,14 +556,14 @@ type GitserverClientCommitGraphFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitserverClientCommitGraphFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c GitserverClientCommitGraphFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitserverClientCommitGraphFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c GitserverClientCommitGraphFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // GitserverClientRefDescriptionsFunc describes the behavior when the
@@ -667,14 +667,14 @@ type GitserverClientRefDescriptionsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitserverClientRefDescriptionsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c GitserverClientRefDescriptionsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitserverClientRefDescriptionsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c GitserverClientRefDescriptionsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // MockLocker is a mock implementation of the Locker interface (from the
@@ -813,12 +813,12 @@ type LockerLockFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LockerLockFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c LockerLockFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LockerLockFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c LockerLockFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }

--- a/enterprise/cmd/worker/internal/codeintel/dbstore.go
+++ b/enterprise/cmd/worker/internal/codeintel/dbstore.go
@@ -22,7 +22,7 @@ func InitDBStore() (*dbstore.Store, error) {
 	return conn.(*dbstore.Store), err
 }
 
-var initDBStore = shared.NewMemoizedConstructor(func() (interface{}, error) {
+var initDBStore = shared.NewMemoizedConstructor(func() (any, error) {
 	observationContext := &observation.Context{
 		Logger:     log15.Root(),
 		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
@@ -47,7 +47,7 @@ func InitDependencyIndexStore() (dbworkerstore.Store, error) {
 	return store.(dbworkerstore.Store), err
 }
 
-var initDependencyIndexStore = shared.NewMemoizedConstructor(func() (interface{}, error) {
+var initDependencyIndexStore = shared.NewMemoizedConstructor(func() (any, error) {
 	observationContext := &observation.Context{
 		Logger:     log15.Root(),
 		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},

--- a/enterprise/cmd/worker/internal/codeintel/gitserver.go
+++ b/enterprise/cmd/worker/internal/codeintel/gitserver.go
@@ -21,7 +21,7 @@ func InitGitserverClient() (*gitserver.Client, error) {
 	return conn.(*gitserver.Client), err
 }
 
-var initGitserverClient = shared.NewMemoizedConstructor(func() (interface{}, error) {
+var initGitserverClient = shared.NewMemoizedConstructor(func() (any, error) {
 	observationContext := &observation.Context{
 		Logger:     log15.Root(),
 		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},

--- a/enterprise/cmd/worker/internal/codeintel/indexing/index_scheduler_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/index_scheduler_test.go
@@ -24,7 +24,7 @@ func TestIndexSchedulerUpdate(t *testing.T) {
 
 	mockSettingStore := NewMockIndexingSettingStore()
 	mockSettingStore.GetLastestSchemaSettingsFunc.SetDefaultReturn(&schema.Settings{
-		SearchRepositoryGroups: map[string][]interface{}{},
+		SearchRepositoryGroups: map[string][]any{},
 	}, nil)
 
 	mockRepoStore := NewMockIndexingRepoStore()
@@ -71,7 +71,7 @@ func TestDisabledAutoindexConfiguration(t *testing.T) {
 
 	mockSettingStore := NewMockIndexingSettingStore()
 	mockSettingStore.GetLastestSchemaSettingsFunc.SetDefaultReturn(&schema.Settings{
-		SearchRepositoryGroups: map[string][]interface{}{},
+		SearchRepositoryGroups: map[string][]any{},
 	}, nil)
 
 	mockRepoStore := NewMockIndexingRepoStore()

--- a/enterprise/cmd/worker/internal/codeintel/indexing/mock_iface_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/mock_iface_test.go
@@ -205,14 +205,14 @@ type DBStoreGetAutoindexDisabledRepositoriesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreGetAutoindexDisabledRepositoriesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c DBStoreGetAutoindexDisabledRepositoriesFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreGetAutoindexDisabledRepositoriesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreGetAutoindexDisabledRepositoriesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreGetRepositoriesWithIndexConfigurationFunc describes the behavior
@@ -316,14 +316,14 @@ type DBStoreGetRepositoriesWithIndexConfigurationFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreGetRepositoriesWithIndexConfigurationFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c DBStoreGetRepositoriesWithIndexConfigurationFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreGetRepositoriesWithIndexConfigurationFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreGetRepositoriesWithIndexConfigurationFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreGetUploadByIDFunc describes the behavior when the GetUploadByID
@@ -428,14 +428,14 @@ type DBStoreGetUploadByIDFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreGetUploadByIDFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreGetUploadByIDFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreGetUploadByIDFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c DBStoreGetUploadByIDFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // DBStoreGetUploadsFunc describes the behavior when the GetUploads method
@@ -539,14 +539,14 @@ type DBStoreGetUploadsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreGetUploadsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreGetUploadsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreGetUploadsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c DBStoreGetUploadsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // DBStoreReferencesForUploadFunc describes the behavior when the
@@ -648,14 +648,14 @@ type DBStoreReferencesForUploadFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreReferencesForUploadFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreReferencesForUploadFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreReferencesForUploadFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreReferencesForUploadFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreWithFunc describes the behavior when the With method of the parent
@@ -750,14 +750,14 @@ type DBStoreWithFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreWithFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c DBStoreWithFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreWithFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c DBStoreWithFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // MockGitserverClient is a mock implementation of the GitserverClient
@@ -943,14 +943,14 @@ type GitserverClientFileExistsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitserverClientFileExistsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c GitserverClientFileExistsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitserverClientFileExistsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c GitserverClientFileExistsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // GitserverClientHeadFunc describes the behavior when the Head method of
@@ -1055,14 +1055,14 @@ type GitserverClientHeadFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitserverClientHeadFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c GitserverClientHeadFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitserverClientHeadFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c GitserverClientHeadFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // GitserverClientListFilesFunc describes the behavior when the ListFiles
@@ -1170,14 +1170,14 @@ type GitserverClientListFilesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitserverClientListFilesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c GitserverClientListFilesFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitserverClientListFilesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c GitserverClientListFilesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // GitserverClientRawContentsFunc describes the behavior when the
@@ -1285,14 +1285,14 @@ type GitserverClientRawContentsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitserverClientRawContentsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c GitserverClientRawContentsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitserverClientRawContentsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c GitserverClientRawContentsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // GitserverClientResolveRevisionFunc describes the behavior when the
@@ -1399,14 +1399,14 @@ type GitserverClientResolveRevisionFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitserverClientResolveRevisionFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c GitserverClientResolveRevisionFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitserverClientResolveRevisionFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c GitserverClientResolveRevisionFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // MockIndexEnqueuer is a mock implementation of the IndexEnqueuer interface
@@ -1553,14 +1553,14 @@ type IndexEnqueuerQueueIndexesForPackageFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c IndexEnqueuerQueueIndexesForPackageFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c IndexEnqueuerQueueIndexesForPackageFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c IndexEnqueuerQueueIndexesForPackageFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c IndexEnqueuerQueueIndexesForPackageFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // IndexEnqueuerQueueIndexesForRepositoryFunc describes the behavior when
@@ -1663,14 +1663,14 @@ type IndexEnqueuerQueueIndexesForRepositoryFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c IndexEnqueuerQueueIndexesForRepositoryFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c IndexEnqueuerQueueIndexesForRepositoryFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c IndexEnqueuerQueueIndexesForRepositoryFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c IndexEnqueuerQueueIndexesForRepositoryFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // MockIndexingRepoStore is a mock implementation of the IndexingRepoStore
@@ -1808,14 +1808,14 @@ type IndexingRepoStoreListRepoNamesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c IndexingRepoStoreListRepoNamesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c IndexingRepoStoreListRepoNamesFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c IndexingRepoStoreListRepoNamesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c IndexingRepoStoreListRepoNamesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // MockIndexingSettingStore is a mock implementation of the
@@ -1955,12 +1955,12 @@ type IndexingSettingStoreGetLastestSchemaSettingsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c IndexingSettingStoreGetLastestSchemaSettingsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c IndexingSettingStoreGetLastestSchemaSettingsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c IndexingSettingStoreGetLastestSchemaSettingsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c IndexingSettingStoreGetLastestSchemaSettingsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }

--- a/enterprise/cmd/worker/internal/codeintel/indexing/mock_scanner_test.go
+++ b/enterprise/cmd/worker/internal/codeintel/indexing/mock_scanner_test.go
@@ -144,14 +144,14 @@ type PackageReferenceScannerCloseFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c PackageReferenceScannerCloseFuncCall) Args() []interface{} {
-	return []interface{}{}
+func (c PackageReferenceScannerCloseFuncCall) Args() []any {
+	return []any{}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c PackageReferenceScannerCloseFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c PackageReferenceScannerCloseFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // PackageReferenceScannerNextFunc describes the behavior when the Next
@@ -250,12 +250,12 @@ type PackageReferenceScannerNextFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c PackageReferenceScannerNextFuncCall) Args() []interface{} {
-	return []interface{}{}
+func (c PackageReferenceScannerNextFuncCall) Args() []any {
+	return []any{}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c PackageReferenceScannerNextFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c PackageReferenceScannerNextFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }

--- a/enterprise/cmd/worker/internal/codeintel/janitor/mock_iface.go
+++ b/enterprise/cmd/worker/internal/codeintel/janitor/mock_iface.go
@@ -282,14 +282,14 @@ type DBStoreDeleteIndexesWithoutRepositoryFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreDeleteIndexesWithoutRepositoryFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreDeleteIndexesWithoutRepositoryFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreDeleteIndexesWithoutRepositoryFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreDeleteIndexesWithoutRepositoryFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreDeleteOldIndexesFunc describes the behavior when the
@@ -394,14 +394,14 @@ type DBStoreDeleteOldIndexesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreDeleteOldIndexesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c DBStoreDeleteOldIndexesFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreDeleteOldIndexesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreDeleteOldIndexesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreDeleteUploadsStuckUploadingFunc describes the behavior when the
@@ -506,14 +506,14 @@ type DBStoreDeleteUploadsStuckUploadingFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreDeleteUploadsStuckUploadingFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreDeleteUploadsStuckUploadingFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreDeleteUploadsStuckUploadingFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreDeleteUploadsStuckUploadingFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreDeleteUploadsWithoutRepositoryFunc describes the behavior when the
@@ -619,14 +619,14 @@ type DBStoreDeleteUploadsWithoutRepositoryFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreDeleteUploadsWithoutRepositoryFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreDeleteUploadsWithoutRepositoryFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreDeleteUploadsWithoutRepositoryFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreDeleteUploadsWithoutRepositoryFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreDirtyRepositoriesFunc describes the behavior when the
@@ -725,14 +725,14 @@ type DBStoreDirtyRepositoriesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreDirtyRepositoriesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c DBStoreDirtyRepositoriesFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreDirtyRepositoriesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreDirtyRepositoriesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreDoneFunc describes the behavior when the Done method of the parent
@@ -827,14 +827,14 @@ type DBStoreDoneFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreDoneFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c DBStoreDoneFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreDoneFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c DBStoreDoneFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // DBStoreGetUploadsFunc describes the behavior when the GetUploads method
@@ -938,14 +938,14 @@ type DBStoreGetUploadsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreGetUploadsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreGetUploadsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreGetUploadsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c DBStoreGetUploadsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // DBStoreHandleFunc describes the behavior when the Handle method of the
@@ -1037,14 +1037,14 @@ type DBStoreHandleFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreHandleFuncCall) Args() []interface{} {
-	return []interface{}{}
+func (c DBStoreHandleFuncCall) Args() []any {
+	return []any{}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreHandleFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c DBStoreHandleFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // DBStoreHardDeleteUploadByIDFunc describes the behavior when the
@@ -1146,19 +1146,19 @@ type DBStoreHardDeleteUploadByIDFuncCall struct {
 // invocation. The variadic slice argument is flattened in this array such
 // that one positional argument and three variadic arguments would result in
 // a slice of four, not two.
-func (c DBStoreHardDeleteUploadByIDFuncCall) Args() []interface{} {
-	trailing := []interface{}{}
+func (c DBStoreHardDeleteUploadByIDFuncCall) Args() []any {
+	trailing := []any{}
 	for _, val := range c.Arg1 {
 		trailing = append(trailing, val)
 	}
 
-	return append([]interface{}{c.Arg0}, trailing...)
+	return append([]any{c.Arg0}, trailing...)
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreHardDeleteUploadByIDFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c DBStoreHardDeleteUploadByIDFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // DBStoreRefreshCommitResolvabilityFunc describes the behavior when the
@@ -1275,14 +1275,14 @@ type DBStoreRefreshCommitResolvabilityFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreRefreshCommitResolvabilityFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+func (c DBStoreRefreshCommitResolvabilityFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreRefreshCommitResolvabilityFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c DBStoreRefreshCommitResolvabilityFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // DBStoreSoftDeleteOldUploadsFunc describes the behavior when the
@@ -1388,14 +1388,14 @@ type DBStoreSoftDeleteOldUploadsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreSoftDeleteOldUploadsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c DBStoreSoftDeleteOldUploadsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreSoftDeleteOldUploadsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreSoftDeleteOldUploadsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreStaleSourcedCommitsFunc describes the behavior when the
@@ -1503,14 +1503,14 @@ type DBStoreStaleSourcedCommitsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreStaleSourcedCommitsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c DBStoreStaleSourcedCommitsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreStaleSourcedCommitsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreStaleSourcedCommitsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreTransactFunc describes the behavior when the Transact method of
@@ -1608,14 +1608,14 @@ type DBStoreTransactFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreTransactFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c DBStoreTransactFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreTransactFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreTransactFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // MockLSIFStore is a mock implementation of the LSIFStore interface (from
@@ -1747,17 +1747,17 @@ type LSIFStoreClearFuncCall struct {
 // invocation. The variadic slice argument is flattened in this array such
 // that one positional argument and three variadic arguments would result in
 // a slice of four, not two.
-func (c LSIFStoreClearFuncCall) Args() []interface{} {
-	trailing := []interface{}{}
+func (c LSIFStoreClearFuncCall) Args() []any {
+	trailing := []any{}
 	for _, val := range c.Arg1 {
 		trailing = append(trailing, val)
 	}
 
-	return append([]interface{}{c.Arg0}, trailing...)
+	return append([]any{c.Arg0}, trailing...)
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LSIFStoreClearFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c LSIFStoreClearFuncCall) Results() []any {
+	return []any{c.Result0}
 }

--- a/enterprise/cmd/worker/internal/codeintel/lsifstore.go
+++ b/enterprise/cmd/worker/internal/codeintel/lsifstore.go
@@ -21,7 +21,7 @@ func InitLSIFStore() (*lsifstore.Store, error) {
 	return conn.(*lsifstore.Store), err
 }
 
-var initLSFIStore = shared.NewMemoizedConstructor(func() (interface{}, error) {
+var initLSFIStore = shared.NewMemoizedConstructor(func() (any, error) {
 	observationContext := &observation.Context{
 		Logger:     log15.Root(),
 		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},

--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -2,8 +2,8 @@
 //
 // Usage:
 //
-//    pipeline := buildkite.Pipeline{}
-//    pipeline.AddStep("check_mark", buildkite.Cmd("./dev/check/all.sh"))
+//	pipeline := buildkite.Pipeline{}
+//	pipeline.AddStep("check_mark", buildkite.Cmd("./dev/check/all.sh"))
 package buildkite
 
 import (
@@ -14,32 +14,32 @@ import (
 
 type Pipeline struct {
 	Env   map[string]string `json:"env,omitempty"`
-	Steps []interface{}     `json:"steps"`
+	Steps []any             `json:"steps"`
 }
 
 type BuildOptions struct {
-	Message  string                 `json:"message,omitempty"`
-	Commit   string                 `json:"commit,omitempty"`
-	Branch   string                 `json:"branch,omitempty"`
-	MetaData map[string]interface{} `json:"meta_data,omitempty"`
-	Env      map[string]string      `json:"env,omitempty"`
+	Message  string            `json:"message,omitempty"`
+	Commit   string            `json:"commit,omitempty"`
+	Branch   string            `json:"branch,omitempty"`
+	MetaData map[string]any    `json:"meta_data,omitempty"`
+	Env      map[string]string `json:"env,omitempty"`
 }
 
 type Step struct {
-	Label            string                 `json:"label"`
-	Command          []string               `json:"command,omitempty"`
-	TimeoutInMinutes string                 `json:"timeout_in_minutes,omitempty"`
-	Trigger          string                 `json:"trigger,omitempty"`
-	Async            bool                   `json:"async,omitempty"`
-	Build            *BuildOptions          `json:"build,omitempty"`
-	Env              map[string]string      `json:"env,omitempty"`
-	Plugins          map[string]interface{} `json:"plugins,omitempty"`
-	ArtifactPaths    string                 `json:"artifact_paths,omitempty"`
-	ConcurrencyGroup string                 `json:"concurrency_group,omitempty"`
-	Concurrency      int                    `json:"concurrency,omitempty"`
-	SoftFail         bool                   `json:"soft_fail,omitempty"`
-	Retry            *RetryOptions          `json:"retry,omitempty"`
-	Agents           map[string]string      `json:"agents,omitempty"`
+	Label            string            `json:"label"`
+	Command          []string          `json:"command,omitempty"`
+	TimeoutInMinutes string            `json:"timeout_in_minutes,omitempty"`
+	Trigger          string            `json:"trigger,omitempty"`
+	Async            bool              `json:"async,omitempty"`
+	Build            *BuildOptions     `json:"build,omitempty"`
+	Env              map[string]string `json:"env,omitempty"`
+	Plugins          map[string]any    `json:"plugins,omitempty"`
+	ArtifactPaths    string            `json:"artifact_paths,omitempty"`
+	ConcurrencyGroup string            `json:"concurrency_group,omitempty"`
+	Concurrency      int               `json:"concurrency,omitempty"`
+	SoftFail         bool              `json:"soft_fail,omitempty"`
+	Retry            *RetryOptions     `json:"retry,omitempty"`
+	Agents           map[string]string `json:"agents,omitempty"`
 }
 
 type RetryOptions struct {
@@ -50,7 +50,7 @@ type AutomaticRetryOptions struct {
 	Limit int `json:"limit,omitempty"`
 }
 
-var Plugins = make(map[string]interface{})
+var Plugins = make(map[string]any)
 
 // BeforeEveryStepOpts are e.g. commands that are run before every AddStep, similar to
 // Plugins.

--- a/enterprise/internal/authz/authz_test.go
+++ b/enterprise/internal/authz/authz_test.go
@@ -493,7 +493,7 @@ func mustURLParse(t *testing.T, u string) *url.URL {
 	return parsed
 }
 
-func asJSON(t *testing.T, v interface{}) string {
+func asJSON(t *testing.T, v any) string {
 	b, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		t.Fatal(err)
@@ -509,7 +509,7 @@ type fakeStore struct {
 }
 
 func (s fakeStore) List(ctx context.Context, opt database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
-	mustMarshalJSONString := func(v interface{}) string {
+	mustMarshalJSONString := func(v any) string {
 		str, err := jsoniter.MarshalToString(v)
 		if err != nil {
 			panic(err)

--- a/enterprise/internal/batches/reconciler/executor_test.go
+++ b/enterprise/internal/batches/reconciler/executor_test.go
@@ -72,7 +72,7 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 		hasCurrentSpec bool
 		plan           *Plan
 
-		sourcerMetadata interface{}
+		sourcerMetadata any
 		sourcerErr      error
 		// Whether or not the source responds to CreateChangeset with "already exists"
 		alreadyExists bool

--- a/enterprise/internal/batches/resolvers/apitest/exec.go
+++ b/enterprise/internal/batches/resolvers/apitest/exec.go
@@ -18,8 +18,8 @@ func MustExec(
 	ctx context.Context,
 	t testing.TB,
 	s *graphql.Schema,
-	in map[string]interface{},
-	out interface{},
+	in map[string]any,
+	out any,
 	query string,
 ) {
 	t.Helper()
@@ -34,8 +34,8 @@ func Exec(
 	ctx context.Context,
 	t testing.TB,
 	s *graphql.Schema,
-	in map[string]interface{},
-	out interface{},
+	in map[string]any,
+	out any,
 	query string,
 ) []*gqlerrors.QueryError {
 	t.Helper()
@@ -47,7 +47,7 @@ func Exec(
 		t.Fatalf("failed to marshal input: %s", err)
 	}
 
-	var anonInput map[string]interface{}
+	var anonInput map[string]any
 	err = json.Unmarshal(b, &anonInput)
 	if err != nil {
 		t.Fatalf("failed to unmarshal input back: %s", err)
@@ -71,7 +71,7 @@ func Exec(
 	return nil
 }
 
-func toJSON(t testing.TB, v interface{}) string {
+func toJSON(t testing.TB, v any) string {
 	data, err := json.Marshal(v)
 	if err != nil {
 		t.Fatal(err)

--- a/enterprise/internal/batches/resolvers/batch_change_connection_test.go
+++ b/enterprise/internal/batches/resolvers/batch_change_connection_test.go
@@ -104,7 +104,7 @@ func TestBatchChangeConnectionResolver(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("first=%d", tc.firstParam), func(t *testing.T) {
-			input := map[string]interface{}{"first": int64(tc.firstParam)}
+			input := map[string]any{"first": int64(tc.firstParam)}
 			var response struct{ BatchChanges apitest.BatchChangeConnection }
 			apitest.MustExec(actor.WithActor(context.Background(), actor.FromUser(userID)), t, s, input, &response, queryBatchChangesConnection)
 
@@ -127,7 +127,7 @@ func TestBatchChangeConnectionResolver(t *testing.T) {
 	t.Run("Cursor based pagination", func(t *testing.T) {
 		var endCursor *string
 		for i := range nodes {
-			input := map[string]interface{}{"first": 1}
+			input := map[string]any{"first": 1}
 			if endCursor != nil {
 				input["after"] = *endCursor
 			}
@@ -225,7 +225,7 @@ func TestBatchChangesListing(t *testing.T) {
 		createBatchChange(t, batchChange)
 
 		userAPIID := string(graphqlbackend.MarshalUserID(userID))
-		input := map[string]interface{}{"node": userAPIID}
+		input := map[string]any{"node": userAPIID}
 
 		var response struct{ Node apitest.User }
 		apitest.MustExec(actorCtx, t, s, input, &response, listNamespacesBatchChanges)
@@ -258,7 +258,7 @@ func TestBatchChangesListing(t *testing.T) {
 		createBatchChange(t, batchChange)
 
 		orgAPIID := string(graphqlbackend.MarshalOrgID(orgID))
-		input := map[string]interface{}{"node": orgAPIID}
+		input := map[string]any{"node": orgAPIID}
 
 		var response struct{ Node apitest.Org }
 		apitest.MustExec(actorCtx, t, s, input, &response, listNamespacesBatchChanges)

--- a/enterprise/internal/batches/resolvers/batch_change_test.go
+++ b/enterprise/internal/batches/resolvers/batch_change_test.go
@@ -81,7 +81,7 @@ func TestBatchChangeResolver(t *testing.T) {
 		ClosedAt: "",
 	}
 
-	input := map[string]interface{}{"batchChange": batchChangeAPIID}
+	input := map[string]any{"batchChange": batchChangeAPIID}
 	{
 		var response struct{ Node apitest.BatchChange }
 		apitest.MustExec(ctx, t, s, input, &response, queryBatchChange)
@@ -91,7 +91,7 @@ func TestBatchChangeResolver(t *testing.T) {
 		}
 	}
 	// Test resolver by namespace and name
-	byNameInput := map[string]interface{}{"name": batchChange.Name, "namespace": namespaceAPIID}
+	byNameInput := map[string]any{"name": batchChange.Name, "namespace": namespaceAPIID}
 	{
 		var response struct{ BatchChange apitest.BatchChange }
 		apitest.MustExec(ctx, t, s, byNameInput, &response, queryBatchChangeByName)

--- a/enterprise/internal/batches/resolvers/batch_spec_test.go
+++ b/enterprise/internal/batches/resolvers/batch_spec_test.go
@@ -87,7 +87,7 @@ func TestBatchSpecResolver(t *testing.T) {
 	userAPIID := string(graphqlbackend.MarshalUserID(userID))
 	orgAPIID := string(graphqlbackend.MarshalOrgID(orgID))
 
-	var unmarshaled interface{}
+	var unmarshaled any
 	err = json.Unmarshal([]byte(spec.RawSpec), &unmarshaled)
 	if err != nil {
 		t.Fatal(err)
@@ -144,7 +144,7 @@ func TestBatchSpecResolver(t *testing.T) {
 		},
 	}
 
-	input := map[string]interface{}{"batchSpec": apiID}
+	input := map[string]any{"batchSpec": apiID}
 	{
 		var response struct{ Node apitest.BatchSpec }
 		apitest.MustExec(actor.WithActor(context.Background(), actor.FromUser(userID)), t, s, input, &response, queryBatchSpecNode)

--- a/enterprise/internal/batches/resolvers/bulk_operation_connection_test.go
+++ b/enterprise/internal/batches/resolvers/bulk_operation_connection_test.go
@@ -123,7 +123,7 @@ func TestBulkOperationConnectionResolver(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("First %d", tc.firstParam), func(t *testing.T) {
-			input := map[string]interface{}{"batchChange": batchChangeAPIID, "first": int64(tc.firstParam)}
+			input := map[string]any{"batchChange": batchChangeAPIID, "first": int64(tc.firstParam)}
 			var response struct {
 				Node apitest.BatchChange
 			}
@@ -151,7 +151,7 @@ func TestBulkOperationConnectionResolver(t *testing.T) {
 
 	var endCursor *string
 	for i := range nodes {
-		input := map[string]interface{}{"batchChange": batchChangeAPIID, "first": 1}
+		input := map[string]any{"batchChange": batchChangeAPIID, "first": 1}
 		if endCursor != nil {
 			input["after"] = *endCursor
 		}

--- a/enterprise/internal/batches/resolvers/bulk_operation_test.go
+++ b/enterprise/internal/batches/resolvers/bulk_operation_test.go
@@ -124,7 +124,7 @@ func TestBulkOperationResolver(t *testing.T) {
 		FinishedAt: "",
 	}
 
-	input := map[string]interface{}{"bulkOperation": bulkOperationAPIID}
+	input := map[string]any{"bulkOperation": bulkOperationAPIID}
 	var response struct{ Node apitest.BulkOperation }
 	apitest.MustExec(actor.WithActor(ctx, actor.FromUser(userID)), t, s, input, &response, queryBulkOperation)
 

--- a/enterprise/internal/batches/resolvers/changeset_apply_preview_connection_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_apply_preview_connection_test.go
@@ -90,7 +90,7 @@ func TestChangesetApplyPreviewConnectionResolver(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		input := map[string]interface{}{"batchSpec": apiID, "first": tc.first}
+		input := map[string]any{"batchSpec": apiID, "first": tc.first}
 		var response struct{ Node apitest.BatchSpec }
 		apitest.MustExec(ctx, t, s, input, &response, queryChangesetApplyPreviewConnection)
 
@@ -106,7 +106,7 @@ func TestChangesetApplyPreviewConnectionResolver(t *testing.T) {
 
 	var endCursor *string
 	for i := range changesetSpecs {
-		input := map[string]interface{}{"batchSpec": apiID, "first": 1}
+		input := map[string]any{"batchSpec": apiID, "first": 1}
 		if endCursor != nil {
 			input["after"] = *endCursor
 		}

--- a/enterprise/internal/batches/resolvers/changeset_apply_preview_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_apply_preview_test.go
@@ -104,7 +104,7 @@ func TestChangesetApplyPreviewResolver(t *testing.T) {
 
 	apiID := string(marshalBatchSpecRandID(batchSpec.RandID))
 
-	input := map[string]interface{}{"batchSpec": apiID}
+	input := map[string]any{"batchSpec": apiID}
 	var response struct{ Node apitest.BatchSpec }
 	apitest.MustExec(ctx, t, s, input, &response, queryChangesetApplyPreview)
 

--- a/enterprise/internal/batches/resolvers/changeset_connection_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_connection_test.go
@@ -158,7 +158,7 @@ func TestChangesetConnectionResolver(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("Unsafe opts %t, first %d", tc.useUnsafeOpts, tc.firstParam), func(t *testing.T) {
-			input := map[string]interface{}{"batchChange": batchChangeAPIID, "first": int64(tc.firstParam)}
+			input := map[string]any{"batchChange": batchChangeAPIID, "first": int64(tc.firstParam)}
 			if tc.useUnsafeOpts {
 				input["reviewState"] = btypes.ChangesetReviewStatePending
 			}
@@ -187,7 +187,7 @@ func TestChangesetConnectionResolver(t *testing.T) {
 
 	var endCursor *string
 	for i := range nodes {
-		input := map[string]interface{}{"batchChange": batchChangeAPIID, "first": 1}
+		input := map[string]any{"batchChange": batchChangeAPIID, "first": 1}
 		if endCursor != nil {
 			input["after"] = *endCursor
 		}

--- a/enterprise/internal/batches/resolvers/changeset_counts_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_counts_test.go
@@ -206,7 +206,7 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 	// End time is when PR1 was merged
 	end := parseJSONTime(t, "2019-10-07T13:13:45Z")
 
-	input := map[string]interface{}{
+	input := map[string]any{
 		"batchChange": string(marshalBatchChangeID(batchChange.ID)),
 		"from":        start,
 		"to":          end,

--- a/enterprise/internal/batches/resolvers/changeset_event_connection_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_event_connection_test.go
@@ -130,7 +130,7 @@ func TestChangesetEventConnectionResolver(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("first=%d", tc.firstParam), func(t *testing.T) {
-			input := map[string]interface{}{"changeset": changesetAPIID, "first": int64(tc.firstParam)}
+			input := map[string]any{"changeset": changesetAPIID, "first": int64(tc.firstParam)}
 			var response struct{ Node apitest.Changeset }
 			apitest.MustExec(actor.WithActor(context.Background(), actor.FromUser(userID)), t, s, input, &response, queryChangesetEventConnection)
 
@@ -152,7 +152,7 @@ func TestChangesetEventConnectionResolver(t *testing.T) {
 
 	var endCursor *string
 	for i := range nodes {
-		input := map[string]interface{}{"changeset": changesetAPIID, "first": 1}
+		input := map[string]any{"changeset": changesetAPIID, "first": 1}
 		if endCursor != nil {
 			input["after"] = *endCursor
 		}

--- a/enterprise/internal/batches/resolvers/changeset_spec_connection_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_spec_connection_test.go
@@ -88,7 +88,7 @@ func TestChangesetSpecConnectionResolver(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		input := map[string]interface{}{"batchSpec": apiID, "first": tc.first}
+		input := map[string]any{"batchSpec": apiID, "first": tc.first}
 		var response struct{ Node apitest.BatchSpec }
 		apitest.MustExec(ctx, t, s, input, &response, queryChangesetSpecConnection)
 
@@ -104,7 +104,7 @@ func TestChangesetSpecConnectionResolver(t *testing.T) {
 
 	var endCursor *string
 	for i := range changesetSpecs {
-		input := map[string]interface{}{"batchSpec": apiID, "first": 1}
+		input := map[string]any{"batchSpec": apiID, "first": 1}
 		if endCursor != nil {
 			input["after"] = *endCursor
 		}

--- a/enterprise/internal/batches/resolvers/changeset_spec_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_spec_test.go
@@ -272,7 +272,7 @@ func TestChangesetSpecResolver(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			input := map[string]interface{}{"id": marshalChangesetSpecRandID(spec.RandID)}
+			input := map[string]any{"id": marshalChangesetSpecRandID(spec.RandID)}
 			var response struct{ Node apitest.ChangesetSpec }
 			apitest.MustExec(ctx, t, s, input, &response, queryChangesetSpecNode)
 

--- a/enterprise/internal/batches/resolvers/changeset_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_test.go
@@ -313,7 +313,7 @@ func TestChangesetResolver(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			apiID := marshalChangesetID(tc.changeset.ID)
-			input := map[string]interface{}{"changeset": apiID}
+			input := map[string]any{"changeset": apiID}
 
 			var response struct{ Node apitest.Changeset }
 			apitest.MustExec(ctx, t, s, input, &response, queryChangeset)

--- a/enterprise/internal/batches/resolvers/code_host_connection_test.go
+++ b/enterprise/internal/batches/resolvers/code_host_connection_test.go
@@ -94,7 +94,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 
 		for _, tc := range tests {
 			t.Run(fmt.Sprintf("First %d", tc.firstParam), func(t *testing.T) {
-				input := map[string]interface{}{"user": userAPIID, "first": int64(tc.firstParam)}
+				input := map[string]any{"user": userAPIID, "first": int64(tc.firstParam)}
 				var response struct {
 					BatchChangesCodeHosts apitest.BatchChangesCodeHostsConnection
 				}
@@ -122,7 +122,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 
 		var endCursor *string
 		for i := range nodes {
-			input := map[string]interface{}{"user": userAPIID, "first": 1}
+			input := map[string]any{"user": userAPIID, "first": 1}
 			if endCursor != nil {
 				input["after"] = *endCursor
 			}
@@ -215,7 +215,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 
 		for _, tc := range tests {
 			t.Run(fmt.Sprintf("First %d", tc.firstParam), func(t *testing.T) {
-				input := map[string]interface{}{"user": userAPIID, "first": int64(tc.firstParam)}
+				input := map[string]any{"user": userAPIID, "first": int64(tc.firstParam)}
 				var response struct{ Node apitest.User }
 				apitest.MustExec(actor.WithActor(context.Background(), actor.FromUser(userID)), t, s, input, &response, queryUserCodeHostConnection)
 
@@ -241,7 +241,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 
 		var endCursor *string
 		for i := range nodes {
-			input := map[string]interface{}{"user": userAPIID, "first": 1}
+			input := map[string]any{"user": userAPIID, "first": 1}
 			if endCursor != nil {
 				input["after"] = *endCursor
 			}

--- a/enterprise/internal/batches/resolvers/errors.go
+++ b/enterprise/internal/batches/resolvers/errors.go
@@ -10,8 +10,8 @@ func (e ErrInvalidFirstParameter) Error() string {
 	return fmt.Sprintf("first param %d is out of range (min=%d, max=%d)", e.First, e.Min, e.Max)
 }
 
-func (e ErrInvalidFirstParameter) Extensions() map[string]interface{} {
-	return map[string]interface{}{"code": "ErrInvalidFirstParameter"}
+func (e ErrInvalidFirstParameter) Extensions() map[string]any {
+	return map[string]any{"code": "ErrInvalidFirstParameter"}
 }
 
 type ErrIDIsZero struct{}
@@ -20,34 +20,34 @@ func (e ErrIDIsZero) Error() string {
 	return "invalid node id"
 }
 
-func (e ErrIDIsZero) Extensions() map[string]interface{} {
-	return map[string]interface{}{"code": "ErrIDIsZero"}
+func (e ErrIDIsZero) Extensions() map[string]any {
+	return map[string]any{"code": "ErrIDIsZero"}
 }
 
 type ErrBatchChangesDisabled struct{ error }
 
-func (e ErrBatchChangesDisabled) Extensions() map[string]interface{} {
-	return map[string]interface{}{"code": "ErrBatchChangesDisabled"}
+func (e ErrBatchChangesDisabled) Extensions() map[string]any {
+	return map[string]any{"code": "ErrBatchChangesDisabled"}
 }
 
 type ErrBatchChangesDisabledForUser struct{ error }
 
-func (e ErrBatchChangesDisabledForUser) Extensions() map[string]interface{} {
-	return map[string]interface{}{"code": "ErrBatchChangesDisabledForUser"}
+func (e ErrBatchChangesDisabledForUser) Extensions() map[string]any {
+	return map[string]any{"code": "ErrBatchChangesDisabledForUser"}
 }
 
 // ErrBatchChangesUnlicensed wraps an underlying licensing.featureNotActivatedError
 // to add an error code.
 type ErrBatchChangesUnlicensed struct{ error }
 
-func (e ErrBatchChangesUnlicensed) Extensions() map[string]interface{} {
-	return map[string]interface{}{"code": "ErrBatchChangesUnlicensed"}
+func (e ErrBatchChangesUnlicensed) Extensions() map[string]any {
+	return map[string]any{"code": "ErrBatchChangesUnlicensed"}
 }
 
 type ErrBatchChangesDisabledDotcom struct{ error }
 
-func (e ErrBatchChangesDisabledDotcom) Extensions() map[string]interface{} {
-	return map[string]interface{}{"code": "ErrBatchChangesDisabledDotcom"}
+func (e ErrBatchChangesDisabledDotcom) Extensions() map[string]any {
+	return map[string]any{"code": "ErrBatchChangesDisabledDotcom"}
 }
 
 type ErrEnsureBatchChangeFailed struct{}
@@ -56,8 +56,8 @@ func (e ErrEnsureBatchChangeFailed) Error() string {
 	return "a batch change in the given namespace and with the given name exists but does not match the given ID"
 }
 
-func (e ErrEnsureBatchChangeFailed) Extensions() map[string]interface{} {
-	return map[string]interface{}{"code": "ErrEnsureBatchChangeFailed"}
+func (e ErrEnsureBatchChangeFailed) Extensions() map[string]any {
+	return map[string]any{"code": "ErrEnsureBatchChangeFailed"}
 }
 
 type ErrApplyClosedBatchChange struct{}
@@ -66,8 +66,8 @@ func (e ErrApplyClosedBatchChange) Error() string {
 	return "existing batch change matched by batch spec is closed"
 }
 
-func (e ErrApplyClosedBatchChange) Extensions() map[string]interface{} {
-	return map[string]interface{}{"code": "ErrApplyClosedBatchChange"}
+func (e ErrApplyClosedBatchChange) Extensions() map[string]any {
+	return map[string]any{"code": "ErrApplyClosedBatchChange"}
 }
 
 type ErrMatchingBatchChangeExists struct{}
@@ -76,8 +76,8 @@ func (e ErrMatchingBatchChangeExists) Error() string {
 	return "a batch change matching the given batch spec already exists"
 }
 
-func (e ErrMatchingBatchChangeExists) Extensions() map[string]interface{} {
-	return map[string]interface{}{"code": "ErrMatchingBatchChangeExists"}
+func (e ErrMatchingBatchChangeExists) Extensions() map[string]any {
+	return map[string]any{"code": "ErrMatchingBatchChangeExists"}
 }
 
 type ErrDuplicateCredential struct{}
@@ -86,8 +86,8 @@ func (e ErrDuplicateCredential) Error() string {
 	return "a credential for this code host already exists"
 }
 
-func (e ErrDuplicateCredential) Extensions() map[string]interface{} {
-	return map[string]interface{}{"code": "ErrDuplicateCredential"}
+func (e ErrDuplicateCredential) Extensions() map[string]any {
+	return map[string]any{"code": "ErrDuplicateCredential"}
 }
 
 type ErrVerifyCredentialFailed struct {
@@ -98,6 +98,6 @@ func (e ErrVerifyCredentialFailed) Error() string {
 	return fmt.Sprintf("Failed to verify the credential:\n```\n%s\n```\n", e.SourceErr)
 }
 
-func (e ErrVerifyCredentialFailed) Extensions() map[string]interface{} {
-	return map[string]interface{}{"code": "ErrVerifyCredentialFailed"}
+func (e ErrVerifyCredentialFailed) Extensions() map[string]any {
+	return map[string]any{"code": "ErrVerifyCredentialFailed"}
 }

--- a/enterprise/internal/batches/resolvers/permissions_test.go
+++ b/enterprise/internal/batches/resolvers/permissions_test.go
@@ -180,7 +180,7 @@ func TestPermissionLevels(t *testing.T) {
 
 					var res struct{ Node apitest.BatchChange }
 
-					input := map[string]interface{}{"batchChange": graphqlID}
+					input := map[string]any{"batchChange": graphqlID}
 					queryBatchChange := `
 				  query($batchChange: ID!) {
 				    node(id: $batchChange) { ... on BatchChange { id, viewerCanAdminister } }
@@ -239,7 +239,7 @@ func TestPermissionLevels(t *testing.T) {
 
 					var res struct{ Node apitest.BatchSpec }
 
-					input := map[string]interface{}{"batchSpec": graphqlID}
+					input := map[string]any{"batchSpec": graphqlID}
 					queryBatchSpec := `
 				  query($batchSpec: ID!) {
 				    node(id: $batchSpec) { ... on BatchSpec { id, viewerCanAdminister } }
@@ -295,7 +295,7 @@ func TestPermissionLevels(t *testing.T) {
 
 					var res struct{ Node apitest.User }
 
-					input := map[string]interface{}{"user": graphqlID}
+					input := map[string]any{"user": graphqlID}
 					queryCodeHosts := `
 				  query($user: ID!) {
 				    node(id: $user) { ... on User { batchChangesCodeHosts { totalCount } } }
@@ -386,7 +386,7 @@ func TestPermissionLevels(t *testing.T) {
 						Node apitest.BatchChangesCredential
 					}
 
-					input := map[string]interface{}{"id": graphqlID}
+					input := map[string]any{"id": graphqlID}
 					queryCodeHosts := `
 				  query($id: ID!) {
 				    node(id: $id) { ... on BatchChangesCredential { id } }
@@ -458,7 +458,7 @@ func TestPermissionLevels(t *testing.T) {
 						CreateBatchChangesCredential apitest.BatchChangesCredential
 					}
 
-					input := map[string]interface{}{
+					input := map[string]any{
 						"externalServiceKind": extsvc.KindGitHub,
 						"externalServiceURL":  "https://github.com/",
 						"credential":          "SOSECRET",
@@ -575,7 +575,7 @@ func TestPermissionLevels(t *testing.T) {
 						DeleteBatchChangesCredential apitest.EmptyResponse
 					}
 
-					input := map[string]interface{}{
+					input := map[string]any{
 						"batchChangesCredential": batchChangesCredentialID,
 					}
 					mutationDeleteBatchChangesCredential := `
@@ -1034,7 +1034,7 @@ func TestRepositoryPermissions(t *testing.T) {
 		// Query batch change and check that we get all changesets
 		userCtx := actor.WithActor(ctx, actor.FromUser(userID))
 
-		input := map[string]interface{}{
+		input := map[string]any{
 			"batchChange": string(marshalBatchChangeID(batchChange.ID)),
 		}
 		testBatchChangeResponse(t, s, userCtx, input, wantBatchChangeResponse{
@@ -1087,7 +1087,7 @@ func TestRepositoryPermissions(t *testing.T) {
 		// Now we query with more filters for the changesets. The hidden changesets
 		// should not be returned, since that would leak information about the
 		// hidden changesets.
-		input = map[string]interface{}{
+		input = map[string]any{
 			"batchChange": string(marshalBatchChangeID(batchChange.ID)),
 			"checkState":  string(btypes.ChangesetCheckStatePassed),
 		}
@@ -1099,7 +1099,7 @@ func TestRepositoryPermissions(t *testing.T) {
 		}
 		testBatchChangeResponse(t, s, userCtx, input, wantCheckStateResponse)
 
-		input = map[string]interface{}{
+		input = map[string]any{
 			"batchChange": string(marshalBatchChangeID(batchChange.ID)),
 			"reviewState": string(btypes.ChangesetReviewStateChangesRequested),
 		}
@@ -1191,7 +1191,7 @@ type wantBatchChangeResponse struct {
 	batchChangeDiffStat apitest.DiffStat
 }
 
-func testBatchChangeResponse(t *testing.T, s *graphql.Schema, ctx context.Context, in map[string]interface{}, w wantBatchChangeResponse) {
+func testBatchChangeResponse(t *testing.T, s *graphql.Schema, ctx context.Context, in map[string]any, w wantBatchChangeResponse) {
 	t.Helper()
 
 	var response struct{ Node apitest.BatchChange }
@@ -1336,7 +1336,7 @@ type wantBatchSpecResponse struct {
 func testBatchSpecResponse(t *testing.T, s *graphql.Schema, ctx context.Context, batchSpecRandID string, w wantBatchSpecResponse) {
 	t.Helper()
 
-	in := map[string]interface{}{
+	in := map[string]any{
 		"batchSpec": string(marshalBatchSpecRandID(batchSpecRandID)),
 	}
 

--- a/enterprise/internal/batches/resolvers/resolver.go
+++ b/enterprise/internal/batches/resolvers/resolver.go
@@ -88,7 +88,7 @@ type batchChangeEventArg struct {
 	BatchChangeID int64 `json:"batch_change_id"`
 }
 
-func logBackendEvent(ctx context.Context, db dbutil.DB, name string, args interface{}) error {
+func logBackendEvent(ctx context.Context, db dbutil.DB, name string, args any) error {
 	actor := actor.FromContext(ctx)
 	jsonArg, err := json.Marshal(args)
 	if err != nil {

--- a/enterprise/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/internal/batches/resolvers/resolver_test.go
@@ -60,7 +60,7 @@ func TestNullIDResilience(t *testing.T) {
 		var response struct{ Node struct{ ID string } }
 
 		query := `query($id: ID!) { node(id: $id) { id } }`
-		if errs := apitest.Exec(ctx, t, s, map[string]interface{}{"id": id}, &response, query); len(errs) > 0 {
+		if errs := apitest.Exec(ctx, t, s, map[string]any{"id": id}, &response, query); len(errs) > 0 {
 			t.Errorf("GraphQL request failed: %#+v", errs[0])
 		}
 
@@ -196,7 +196,7 @@ func TestCreateBatchSpec(t *testing.T) {
 				changesetSpecIDs[i] = marshalChangesetSpecRandID(spec.RandID)
 			}
 
-			input := map[string]interface{}{
+			input := map[string]any{
 				"namespace":      userAPIID,
 				"batchSpec":      rawSpec,
 				"changesetSpecs": changesetSpecIDs,
@@ -215,7 +215,7 @@ func TestCreateBatchSpec(t *testing.T) {
 					t.Errorf("unexpected error(s): %+v", errs)
 				}
 
-				var unmarshaled interface{}
+				var unmarshaled any
 				err = json.Unmarshal([]byte(rawSpec), &unmarshaled)
 				if err != nil {
 					t.Fatal(err)
@@ -310,7 +310,7 @@ func TestCreateChangesetSpec(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	input := map[string]interface{}{
+	input := map[string]any{
 		"changesetSpec": ct.NewRawChangesetSpecGitBranch(graphqlbackend.MarshalRepositoryID(repo.ID), "d34db33f"),
 	}
 
@@ -426,7 +426,7 @@ func TestApplyBatchChange(t *testing.T) {
 	}
 
 	userAPIID := string(graphqlbackend.MarshalUserID(userID))
-	input := map[string]interface{}{
+	input := map[string]any{
 		"batchSpec": string(marshalBatchSpecRandID(batchSpec.RandID)),
 	}
 
@@ -555,7 +555,7 @@ func TestCreateBatchChange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	input := map[string]interface{}{
+	input := map[string]any{
 		"batchSpec": string(marshalBatchSpecRandID(batchSpec.RandID)),
 	}
 
@@ -630,10 +630,10 @@ func TestApplyOrCreateBatchSpecWithPublicationStates(t *testing.T) {
 	// them with the same test code provided we special case the response type
 	// handling.
 	for name, tc := range map[string]struct {
-		exec func(ctx context.Context, t testing.TB, s *graphql.Schema, in map[string]interface{}) (*apitest.BatchChange, error)
+		exec func(ctx context.Context, t testing.TB, s *graphql.Schema, in map[string]any) (*apitest.BatchChange, error)
 	}{
 		"applyBatchChange": {
-			exec: func(ctx context.Context, t testing.TB, s *graphql.Schema, in map[string]interface{}) (*apitest.BatchChange, error) {
+			exec: func(ctx context.Context, t testing.TB, s *graphql.Schema, in map[string]any) (*apitest.BatchChange, error) {
 				var response struct{ ApplyBatchChange apitest.BatchChange }
 				if errs := apitest.Exec(ctx, t, s, in, &response, mutationApplyBatchChange); errs != nil {
 					return nil, errors.Newf("GraphQL errors: %v", errs)
@@ -642,7 +642,7 @@ func TestApplyOrCreateBatchSpecWithPublicationStates(t *testing.T) {
 			},
 		},
 		"createBatchChange": {
-			exec: func(ctx context.Context, t testing.TB, s *graphql.Schema, in map[string]interface{}) (*apitest.BatchChange, error) {
+			exec: func(ctx context.Context, t testing.TB, s *graphql.Schema, in map[string]any) (*apitest.BatchChange, error) {
 				var response struct{ CreateBatchChange apitest.BatchChange }
 				if errs := apitest.Exec(ctx, t, s, in, &response, mutationCreateBatchChange); errs != nil {
 					return nil, errors.Newf("GraphQL errors: %v", errs)
@@ -685,7 +685,7 @@ func TestApplyOrCreateBatchSpecWithPublicationStates(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// Handle the interesting error cases for different
 			// publicationStates inputs.
-			for name, states := range map[string][]map[string]interface{}{
+			for name, states := range map[string][]map[string]any{
 				"other batch spec": {
 					{
 						"changesetSpec":    marshalChangesetSpecRandID(otherChangesetSpec.RandID),
@@ -722,7 +722,7 @@ func TestApplyOrCreateBatchSpecWithPublicationStates(t *testing.T) {
 				},
 			} {
 				t.Run(name, func(t *testing.T) {
-					input := map[string]interface{}{
+					input := map[string]any{
 						"batchSpec":         string(marshalBatchSpecRandID(batchSpec.RandID)),
 						"publicationStates": states,
 					}
@@ -734,9 +734,9 @@ func TestApplyOrCreateBatchSpecWithPublicationStates(t *testing.T) {
 
 			// Finally, let's actually make a legit apply.
 			t.Run("success", func(t *testing.T) {
-				input := map[string]interface{}{
+				input := map[string]any{
 					"batchSpec": string(marshalBatchSpecRandID(batchSpec.RandID)),
-					"publicationStates": []map[string]interface{}{
+					"publicationStates": []map[string]any{
 						{
 							"changesetSpec":    marshalChangesetSpecRandID(changesetSpec.RandID),
 							"publicationState": true,
@@ -821,7 +821,7 @@ func TestMoveBatchChange(t *testing.T) {
 	// Move to a new name
 	batchChangeAPIID := string(marshalBatchChangeID(batchChange.ID))
 	newBatchChagneName := "new-name"
-	input := map[string]interface{}{
+	input := map[string]any{
 		"batchChange": batchChangeAPIID,
 		"newName":     newBatchChagneName,
 	}
@@ -842,7 +842,7 @@ func TestMoveBatchChange(t *testing.T) {
 
 	// Move to a new namespace
 	orgAPIID := graphqlbackend.MarshalOrgID(orgID)
-	input = map[string]interface{}{
+	input = map[string]any{
 		"batchChange":  string(marshalBatchChangeID(batchChange.ID)),
 		"newNamespace": orgAPIID,
 	}
@@ -1081,7 +1081,7 @@ func TestCreateBatchChangesCredential(t *testing.T) {
 	})
 
 	t.Run("User credential", func(t *testing.T) {
-		input := map[string]interface{}{
+		input := map[string]any{
 			"user":                graphqlbackend.MarshalUserID(userID),
 			"externalServiceKind": string(extsvc.KindGitHub),
 			"externalServiceURL":  "https://github.com/",
@@ -1127,7 +1127,7 @@ func TestCreateBatchChangesCredential(t *testing.T) {
 		}
 	})
 	t.Run("Site credential", func(t *testing.T) {
-		input := map[string]interface{}{
+		input := map[string]any{
 			"user":                nil,
 			"externalServiceKind": string(extsvc.KindGitHub),
 			"externalServiceURL":  "https://github.com/",
@@ -1221,7 +1221,7 @@ func TestDeleteBatchChangesCredential(t *testing.T) {
 	}
 
 	t.Run("User credential", func(t *testing.T) {
-		input := map[string]interface{}{
+		input := map[string]any{
 			"batchChangesCredential": marshalBatchChangesCredentialID(userCred.ID, false),
 		}
 
@@ -1243,7 +1243,7 @@ func TestDeleteBatchChangesCredential(t *testing.T) {
 	})
 
 	t.Run("Site credential", func(t *testing.T) {
-		input := map[string]interface{}{
+		input := map[string]any{
 			"batchChangesCredential": marshalBatchChangesCredentialID(userCred.ID, true),
 		}
 
@@ -1304,8 +1304,8 @@ func TestCreateChangesetComments(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	generateInput := func() map[string]interface{} {
-		return map[string]interface{}{
+	generateInput := func() map[string]any {
+		return map[string]any{
 			"batchChange": marshalBatchChangeID(batchChange.ID),
 			"changesets":  []string{string(marshalChangesetID(changeset.ID))},
 			"body":        "test-body",
@@ -1413,8 +1413,8 @@ func TestReenqueueChangesets(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	generateInput := func() map[string]interface{} {
-		return map[string]interface{}{
+	generateInput := func() map[string]any {
+		return map[string]any{
 			"batchChange": marshalBatchChangeID(batchChange.ID),
 			"changesets":  []string{string(marshalChangesetID(changeset.ID))},
 		}
@@ -1524,8 +1524,8 @@ func TestMergeChangesets(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	generateInput := func() map[string]interface{} {
-		return map[string]interface{}{
+	generateInput := func() map[string]any {
+		return map[string]any{
 			"batchChange": marshalBatchChangeID(batchChange.ID),
 			"changesets":  []string{string(marshalChangesetID(changeset.ID))},
 		}
@@ -1612,7 +1612,7 @@ func TestResolver_CreateBatchSpecExecution(t *testing.T) {
 	}
 	testSpec := `testSpec: yeah`
 	mutateAndAssert := func(namespaceID, expectNamespaceID string) {
-		input := map[string]interface{}{
+		input := map[string]any{
 			"spec": testSpec,
 		}
 		if namespaceID != "" {
@@ -1709,8 +1709,8 @@ func TestCloseChangesets(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	generateInput := func() map[string]interface{} {
-		return map[string]interface{}{
+	generateInput := func() map[string]any {
+		return map[string]any{
 			"batchChange": marshalBatchChangeID(batchChange.ID),
 			"changesets":  []string{string(marshalChangesetID(changeset.ID))},
 		}
@@ -1836,8 +1836,8 @@ func TestPublishChangesets(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	generateInput := func() map[string]interface{} {
-		return map[string]interface{}{
+	generateInput := func() map[string]any {
+		return map[string]any{
 			"batchChange": marshalBatchChangeID(batchChange.ID),
 			"changesets": []string{
 				string(marshalChangesetID(publishableChangeset.ID)),

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -568,7 +568,7 @@ var ErrChangesetsForJobNotFound = errors.New("some changesets could not be found
 // CreateChangesetJobs creates one changeset job for each given Changeset in the
 // given BatchChange, checking whether the actor in the context has permission to
 // trigger a job, and enqueues it.
-func (s *Service) CreateChangesetJobs(ctx context.Context, batchChangeID int64, ids []int64, jobType btypes.ChangesetJobType, payload interface{}, listOpts store.ListChangesetsOpts) (bulkGroupID string, err error) {
+func (s *Service) CreateChangesetJobs(ctx context.Context, batchChangeID int64, ids []int64, jobType btypes.ChangesetJobType, payload any, listOpts store.ListChangesetsOpts) (bulkGroupID string, err error) {
 	traceTitle := fmt.Sprintf("batchChangeID: %d, len(changesets): %d", batchChangeID, len(ids))
 	tr, ctx := trace.New(ctx, "service.CreateChangesetJobs", traceTitle)
 	defer func() {

--- a/enterprise/internal/batches/sources/fake.go
+++ b/enterprise/internal/batches/sources/fake.go
@@ -59,7 +59,7 @@ type FakeChangesetSource struct {
 
 	// The metadata the FakeChangesetSource should set on the created/updated
 	// Changeset with changeset.SetMetadata.
-	FakeMetadata interface{}
+	FakeMetadata any
 
 	// Whether or not the changeset already ChangesetExists on the code host at the time
 	// when CreateChangeset is called.

--- a/enterprise/internal/batches/sources/main_test.go
+++ b/enterprise/internal/batches/sources/main_test.go
@@ -98,7 +98,7 @@ func save(t testing.TB, rec *recorder.Recorder) {
 	}
 }
 
-func marshalJSON(t testing.TB, v interface{}) string {
+func marshalJSON(t testing.TB, v any) string {
 	t.Helper()
 
 	bs, err := json.Marshal(v)

--- a/enterprise/internal/batches/sources/sources_test.go
+++ b/enterprise/internal/batches/sources/sources_test.go
@@ -226,7 +226,7 @@ func TestGitserverPushConfig(t *testing.T) {
 		repoName            string
 		externalServiceType string
 		config              string
-		repoMetadata        interface{}
+		repoMetadata        any
 		authenticator       auth.Authenticator
 		wantPushConfig      *protocol.PushConfig
 		wantErr             error

--- a/enterprise/internal/batches/store/changeset_specs_test.go
+++ b/enterprise/internal/batches/store/changeset_specs_test.go
@@ -807,7 +807,7 @@ func testStoreChangesetSpecsCurrentState(t *testing.T, ctx context.Context, s *S
 		opts.BatchChange = batchChange.ID
 		opts.CurrentSpec = oldSpecs[state].ID
 		opts.OwnedByBatchChange = batchChange.ID
-		opts.Metadata = map[string]interface{}{"Title": string(state)}
+		opts.Metadata = map[string]any{"Title": string(state)}
 		changesets[state] = ct.CreateChangeset(t, ctx, s, *opts)
 	}
 
@@ -940,7 +940,7 @@ func testStoreChangesetSpecsCurrentStateAndTextSearch(t *testing.T, ctx context.
 		ExternalID:          "5678",
 		ExternalState:       btypes.ChangesetExternalStateOpen,
 		OwnedByBatchChange:  batchChange.ID,
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"Title": "foo",
 		},
 	})
@@ -952,7 +952,7 @@ func testStoreChangesetSpecsCurrentStateAndTextSearch(t *testing.T, ctx context.
 		ExternalID:          "5679",
 		ExternalState:       btypes.ChangesetExternalStateOpen,
 		OwnedByBatchChange:  batchChange.ID,
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"Title": "bar",
 		},
 	})
@@ -964,7 +964,7 @@ func testStoreChangesetSpecsCurrentStateAndTextSearch(t *testing.T, ctx context.
 		ExternalID:          "5680",
 		ExternalState:       btypes.ChangesetExternalStateClosed,
 		OwnedByBatchChange:  batchChange.ID,
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"Title": "foo",
 		},
 	})
@@ -1097,7 +1097,7 @@ func testStoreChangesetSpecsTextSearch(t *testing.T, ctx context.Context, s *Sto
 		ExternalServiceType: repos[0].ExternalRepo.ServiceType,
 		ExternalID:          "1234",
 		OwnedByBatchChange:  batchChange.ID,
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"Title": "Tracked GitHub",
 		},
 	})
@@ -1108,7 +1108,7 @@ func testStoreChangesetSpecsTextSearch(t *testing.T, ctx context.Context, s *Sto
 		ExternalServiceType: repos[1].ExternalRepo.ServiceType,
 		ExternalID:          "1234",
 		OwnedByBatchChange:  batchChange.ID,
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"title": "Tracked GitLab",
 		},
 	})
@@ -1119,7 +1119,7 @@ func testStoreChangesetSpecsTextSearch(t *testing.T, ctx context.Context, s *Sto
 		ExternalServiceType: repos[0].ExternalRepo.ServiceType,
 		ExternalID:          "5678",
 		OwnedByBatchChange:  batchChange.ID,
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"Title": "GitHub branch",
 		},
 	})
@@ -1130,7 +1130,7 @@ func testStoreChangesetSpecsTextSearch(t *testing.T, ctx context.Context, s *Sto
 		ExternalServiceType: repos[1].ExternalRepo.ServiceType,
 		ExternalID:          "5678",
 		OwnedByBatchChange:  batchChange.ID,
-		Metadata: map[string]interface{}{
+		Metadata: map[string]any{
 			"title": "GitLab branch",
 		},
 	})

--- a/enterprise/internal/batches/store/changesets.go
+++ b/enterprise/internal/batches/store/changesets.go
@@ -152,7 +152,7 @@ func (s *Store) changesetWriteQuery(q string, includeID bool, c *btypes.Changese
 		uiPublicationState = nullStringColumn(string(*state))
 	}
 
-	vars := []interface{}{
+	vars := []any{
 		sqlf.Join(changesetInsertColumns, ", "),
 		c.RepoID,
 		c.CreatedAt,
@@ -740,7 +740,7 @@ func updateChangesetCodeHostStateQuery(c *btypes.Changeset) (*sqlf.Query, error)
 	// Not being able to find a title is fine, we just have a NULL in the database then.
 	title, _ := c.Title()
 
-	vars := []interface{}{
+	vars := []any{
 		sqlf.Join(changesetCodeHostStateInsertColumns, ", "),
 		c.UpdatedAt,
 		metadata,
@@ -976,7 +976,7 @@ type jsonBatchChangeChangesetSet struct {
 }
 
 // Scan implements the Scanner interface.
-func (n *jsonBatchChangeChangesetSet) Scan(value interface{}) error {
+func (n *jsonBatchChangeChangesetSet) Scan(value any) error {
 	m := make(map[int64]btypes.BatchChangeAssoc)
 
 	switch value := value.(type) {

--- a/enterprise/internal/batches/store/changesets_test.go
+++ b/enterprise/internal/batches/store/changesets_test.go
@@ -1662,7 +1662,7 @@ func testStoreListChangesetsTextSearch(t *testing.T, ctx context.Context, s *Sto
 		esType string,
 		repo *types.Repo,
 		externalID string,
-		metadata interface{},
+		metadata any,
 		spec *btypes.ChangesetSpec,
 	) *btypes.Changeset {
 		var specID int64
@@ -1770,7 +1770,7 @@ func testStoreListChangesetsTextSearch(t *testing.T, ctx context.Context, s *Sto
 		extsvc.TypeGitHub,
 		githubRepo,
 		"",
-		map[string]interface{}{},
+		map[string]any{},
 		createChangesetSpec("Eventually fix some bugs, but not a bunch"),
 	)
 

--- a/enterprise/internal/batches/store/store.go
+++ b/enterprise/internal/batches/store/store.go
@@ -133,7 +133,7 @@ func (s *Store) queryCount(ctx context.Context, q *sqlf.Query) (int, error) {
 
 // scanner captures the Scan method of sql.Rows and sql.Row
 type scanner interface {
-	Scan(dst ...interface{}) error
+	Scan(dst ...any) error
 }
 
 // a scanFunc scans one or more rows from a scanner, returning
@@ -152,7 +152,7 @@ func scanAll(rows *sql.Rows, scan scanFunc) (err error) {
 	return rows.Err()
 }
 
-func jsonbColumn(metadata interface{}) (msg json.RawMessage, err error) {
+func jsonbColumn(metadata any) (msg json.RawMessage, err error) {
 	switch m := metadata.(type) {
 	case nil:
 		msg = json.RawMessage("{}")

--- a/enterprise/internal/batches/store/text_search_test.go
+++ b/enterprise/internal/batches/store/text_search_test.go
@@ -13,31 +13,31 @@ func TestTextSearchTermToClause(t *testing.T) {
 	for name, tc := range map[string]struct {
 		term      search.TextSearchTerm
 		fields    []string
-		wantArgs  []interface{}
+		wantArgs  []any
 		wantQuery string
 	}{
 		"one positive field": {
 			term:      search.TextSearchTerm{Term: "foo"},
 			fields:    []string{"field"},
-			wantArgs:  []interface{}{"foo"},
+			wantArgs:  []any{"foo"},
 			wantQuery: `(field ~* ('\m'||$1||'\M'))`,
 		},
 		"one negative field": {
 			term:      search.TextSearchTerm{Term: "foo", Not: true},
 			fields:    []string{"field"},
-			wantArgs:  []interface{}{"foo"},
+			wantArgs:  []any{"foo"},
 			wantQuery: `(field !~* ('\m'||$1||'\M'))`,
 		},
 		"two positive fields": {
 			term:      search.TextSearchTerm{Term: "foo"},
 			fields:    []string{"field", "paddock"},
-			wantArgs:  []interface{}{"foo", "foo"},
+			wantArgs:  []any{"foo", "foo"},
 			wantQuery: `(field ~* ('\m'||$1||'\M') OR paddock ~* ('\m'||$2||'\M'))`,
 		},
 		"two negative fields": {
 			term:      search.TextSearchTerm{Term: "foo", Not: true},
 			fields:    []string{"field", "paddock"},
-			wantArgs:  []interface{}{"foo", "foo"},
+			wantArgs:  []any{"foo", "foo"},
 			wantQuery: `(field !~* ('\m'||$1||'\M') AND paddock !~* ('\m'||$2||'\M'))`,
 		},
 	} {

--- a/enterprise/internal/batches/syncer/queue.go
+++ b/enterprise/internal/batches/syncer/queue.go
@@ -57,7 +57,7 @@ func (pq *changesetPriorityQueue) Swap(i, j int) {
 }
 
 // Push is here to implement the Heap interface, please use Upsert
-func (pq *changesetPriorityQueue) Push(x interface{}) {
+func (pq *changesetPriorityQueue) Push(x any) {
 	n := len(pq.items)
 	item := x.(scheduledSync)
 	pq.index[item.changesetID] = n
@@ -65,7 +65,7 @@ func (pq *changesetPriorityQueue) Push(x interface{}) {
 }
 
 // Pop is not to be used directly, use heap.Pop(pq)
-func (pq *changesetPriorityQueue) Pop() interface{} {
+func (pq *changesetPriorityQueue) Pop() any {
 	item := pq.items[len(pq.items)-1]
 	delete(pq.index, item.changesetID)
 	pq.items = pq.items[:len(pq.items)-1]

--- a/enterprise/internal/batches/testing/changeset.go
+++ b/enterprise/internal/batches/testing/changeset.go
@@ -48,7 +48,7 @@ type TestChangesetOpts struct {
 	IsArchived bool
 	Archive    bool
 
-	Metadata interface{}
+	Metadata any
 }
 
 type CreateChangeseter interface {

--- a/enterprise/internal/batches/testing/changeset_spec.go
+++ b/enterprise/internal/batches/testing/changeset_spec.go
@@ -28,7 +28,7 @@ type TestSpecOpts struct {
 
 	// If this is set along with headRef, the changesetSpec will have Published
 	// set.
-	Published interface{}
+	Published any
 
 	Title             string
 	Body              string

--- a/enterprise/internal/batches/testing/specs.go
+++ b/enterprise/internal/batches/testing/specs.go
@@ -138,7 +138,7 @@ func NewRawChangesetSpecExisting(repo graphql.ID, externalID string) string {
 	return fmt.Sprintf(tmpl, repo, externalID)
 }
 
-func MarshalJSON(t testing.TB, v interface{}) string {
+func MarshalJSON(t testing.TB, v any) string {
 	t.Helper()
 
 	bs, err := json.Marshal(v)

--- a/enterprise/internal/batches/types/batch_spec.go
+++ b/enterprise/internal/batches/types/batch_spec.go
@@ -75,8 +75,8 @@ type BatchSpecStep struct {
 }
 
 type BatchChangeImportChangeset struct {
-	Repository  string        `json:"repository" yaml:"repository"`
-	ExternalIDs []interface{} `json:"externalIDs" yaml:"externalIDs"`
+	Repository  string `json:"repository" yaml:"repository"`
+	ExternalIDs []any  `json:"externalIDs" yaml:"externalIDs"`
 }
 
 type ChangesetTemplate struct {

--- a/enterprise/internal/batches/types/changeset.go
+++ b/enterprise/internal/batches/types/changeset.go
@@ -244,7 +244,7 @@ type Changeset struct {
 	RepoID              api.RepoID
 	CreatedAt           time.Time
 	UpdatedAt           time.Time
-	Metadata            interface{}
+	Metadata            any
 	BatchChanges        []BatchChangeAssoc
 	ExternalID          string
 	ExternalServiceType string
@@ -359,7 +359,7 @@ func (c *Changeset) SetDiffStat(stat *diff.Stat) {
 	}
 }
 
-func (c *Changeset) SetMetadata(meta interface{}) error {
+func (c *Changeset) SetMetadata(meta any) error {
 	switch pr := meta.(type) {
 	case *github.PullRequest:
 		c.Metadata = pr
@@ -915,7 +915,7 @@ type ChangesetsStats struct {
 
 // ChangesetEventKindFor returns the ChangesetEventKind for the given
 // specific code host event.
-func ChangesetEventKindFor(e interface{}) (ChangesetEventKind, error) {
+func ChangesetEventKindFor(e any) (ChangesetEventKind, error) {
 	switch e := e.(type) {
 	case *github.AssignedEvent:
 		return ChangesetEventKindGitHubAssigned, nil
@@ -988,7 +988,7 @@ func ChangesetEventKindFor(e interface{}) (ChangesetEventKind, error) {
 
 // NewChangesetEventMetadata returns a new metadata object for the given
 // ChangesetEventKind.
-func NewChangesetEventMetadata(k ChangesetEventKind) (interface{}, error) {
+func NewChangesetEventMetadata(k ChangesetEventKind) (any, error) {
 	switch {
 	case strings.HasPrefix(string(k), "bitbucketserver"):
 		switch k {

--- a/enterprise/internal/batches/types/changeset_event.go
+++ b/enterprise/internal/batches/types/changeset_event.go
@@ -17,8 +17,8 @@ import (
 
 type changesetEventUpdateMismatchError struct {
 	field    string
-	original interface{}
-	revised  interface{}
+	original any
+	revised  any
 }
 
 func (e *changesetEventUpdateMismatchError) Error() string {
@@ -90,7 +90,7 @@ type ChangesetEvent struct {
 	Key         string // Deduplication key
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
-	Metadata    interface{}
+	Metadata    any
 }
 
 // Clone returns a clone of a ChangesetEvent.

--- a/enterprise/internal/batches/types/changeset_job.go
+++ b/enterprise/internal/batches/types/changeset_job.go
@@ -77,7 +77,7 @@ type ChangesetJob struct {
 	UserID        int32
 	ChangesetID   int64
 	JobType       ChangesetJobType
-	Payload       interface{}
+	Payload       any
 
 	// workerutil fields
 

--- a/enterprise/internal/batches/types/changeset_test.go
+++ b/enterprise/internal/batches/types/changeset_test.go
@@ -93,7 +93,7 @@ func TestChangeset_DiffStat(t *testing.T) {
 
 func TestChangeset_SetMetadata(t *testing.T) {
 	for name, tc := range map[string]struct {
-		meta interface{}
+		meta any
 		want *Changeset
 	}{
 		"bitbucketserver": {
@@ -153,7 +153,7 @@ func TestChangeset_SetMetadata(t *testing.T) {
 
 func TestChangeset_Title(t *testing.T) {
 	want := "foo"
-	for name, meta := range map[string]interface{}{
+	for name, meta := range map[string]any{
 		"bitbucketserver": &bitbucketserver.PullRequest{
 			Title: want,
 		},
@@ -186,7 +186,7 @@ func TestChangeset_Title(t *testing.T) {
 
 func TestChangeset_ExternalCreatedAt(t *testing.T) {
 	want := time.Unix(10, 0)
-	for name, meta := range map[string]interface{}{
+	for name, meta := range map[string]any{
 		"bitbucketserver": &bitbucketserver.PullRequest{
 			CreatedDate: 10 * 1000,
 		},
@@ -216,7 +216,7 @@ func TestChangeset_ExternalCreatedAt(t *testing.T) {
 
 func TestChangeset_Body(t *testing.T) {
 	want := "foo"
-	for name, meta := range map[string]interface{}{
+	for name, meta := range map[string]any{
 		"bitbucketserver": &bitbucketserver.PullRequest{
 			Description: want,
 		},
@@ -249,7 +249,7 @@ func TestChangeset_Body(t *testing.T) {
 
 func TestChangeset_URL(t *testing.T) {
 	want := "foo"
-	for name, meta := range map[string]interface{}{
+	for name, meta := range map[string]any{
 		"bitbucketserver": &bitbucketserver.PullRequest{
 			Links: struct {
 				Self []struct {
@@ -290,7 +290,7 @@ func TestChangeset_URL(t *testing.T) {
 
 func TestChangeset_HeadRefOid(t *testing.T) {
 	for name, tc := range map[string]struct {
-		meta interface{}
+		meta any
 		want string
 	}{
 		"bitbucketserver": {
@@ -330,7 +330,7 @@ func TestChangeset_HeadRefOid(t *testing.T) {
 
 func TestChangeset_HeadRef(t *testing.T) {
 	for name, tc := range map[string]struct {
-		meta interface{}
+		meta any
 		want string
 	}{
 		"bitbucketserver": {
@@ -372,7 +372,7 @@ func TestChangeset_HeadRef(t *testing.T) {
 
 func TestChangeset_BaseRefOid(t *testing.T) {
 	for name, tc := range map[string]struct {
-		meta interface{}
+		meta any
 		want string
 	}{
 		"bitbucketserver": {
@@ -412,7 +412,7 @@ func TestChangeset_BaseRefOid(t *testing.T) {
 
 func TestChangeset_BaseRef(t *testing.T) {
 	for name, tc := range map[string]struct {
-		meta interface{}
+		meta any
 		want string
 	}{
 		"bitbucketserver": {
@@ -454,7 +454,7 @@ func TestChangeset_BaseRef(t *testing.T) {
 
 func TestChangeset_Labels(t *testing.T) {
 	for name, tc := range map[string]struct {
-		meta interface{}
+		meta any
 		want []ChangesetLabel
 	}{
 		"bitbucketserver": {

--- a/enterprise/internal/batches/types/scheduler/window/rate.go
+++ b/enterprise/internal/batches/types/scheduler/window/rate.go
@@ -66,7 +66,7 @@ func parseRateUnit(raw string) (rateUnit, error) {
 // parseRate parses a rate given either as a raw integer (which will be
 // interpreted as a rate per second), a string "unlimited" (which will be
 // interpreted, surprisingly, as unlimited), or a string in the form "N/UNIT".
-func parseRate(raw interface{}) (rate, error) {
+func parseRate(raw any) (rate, error) {
 	switch v := raw.(type) {
 	case int:
 		if v == 0 {

--- a/enterprise/internal/batches/types/scheduler/window/rate_test.go
+++ b/enterprise/internal/batches/types/scheduler/window/rate_test.go
@@ -53,7 +53,7 @@ func TestParseRateUnit(t *testing.T) {
 
 func TestParseRate(t *testing.T) {
 	t.Run("errors", func(t *testing.T) {
-		for name, in := range map[string]interface{}{
+		for name, in := range map[string]any{
 			"nil":                                nil,
 			"non-zero int":                       1,
 			"empty string":                       "",
@@ -76,7 +76,7 @@ func TestParseRate(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		for name, tc := range map[string]struct {
-			in   interface{}
+			in   any
 			want rate
 		}{
 			"zero": {

--- a/enterprise/internal/batches/webhooks/bitbucketserver.go
+++ b/enterprise/internal/batches/webhooks/bitbucketserver.go
@@ -61,7 +61,7 @@ func (h *BitbucketServerWebhook) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	}
 }
 
-func (h *BitbucketServerWebhook) parseEvent(r *http.Request) (interface{}, *types.ExternalService, *httpError) {
+func (h *BitbucketServerWebhook) parseEvent(r *http.Request) (any, *types.ExternalService, *httpError) {
 	payload, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, nil, &httpError{http.StatusInternalServerError, err}
@@ -119,7 +119,7 @@ func (h *BitbucketServerWebhook) parseEvent(r *http.Request) (interface{}, *type
 	return e, extSvc, nil
 }
 
-func (h *BitbucketServerWebhook) convertEvent(theirs interface{}) (prs []PR, ours keyer) {
+func (h *BitbucketServerWebhook) convertEvent(theirs any) (prs []PR, ours keyer) {
 	log15.Debug("Bitbucket Server webhook received", "type", fmt.Sprintf("%T", theirs))
 
 	switch e := theirs.(type) {

--- a/enterprise/internal/batches/webhooks/github.go
+++ b/enterprise/internal/batches/webhooks/github.go
@@ -53,7 +53,7 @@ func (h *GitHubWebhook) Register(router *webhooks.GitHubWebhook) {
 
 // handleGithubWebhook is the entry point for webhooks from the webhook router, see the events
 // it's registered to handle in GitHubWebhook.Register
-func (h *GitHubWebhook) handleGitHubWebhook(ctx context.Context, extSvc *types.ExternalService, payload interface{}) error {
+func (h *GitHubWebhook) handleGitHubWebhook(ctx context.Context, extSvc *types.ExternalService, payload any) error {
 	m := new(multierror.Error)
 	externalServiceID, err := extractExternalServiceID(extSvc)
 	if err != nil {
@@ -75,7 +75,7 @@ func (h *GitHubWebhook) handleGitHubWebhook(ctx context.Context, extSvc *types.E
 	return m.ErrorOrNil()
 }
 
-func (h *GitHubWebhook) convertEvent(ctx context.Context, externalServiceID string, theirs interface{}) (prs []PR, ours keyer) {
+func (h *GitHubWebhook) convertEvent(ctx context.Context, externalServiceID string, theirs any) (prs []PR, ours keyer) {
 	log15.Debug("GitHub webhook received", "type", fmt.Sprintf("%T", theirs))
 	switch e := theirs.(type) {
 	case *gh.IssueCommentEvent:

--- a/enterprise/internal/batches/webhooks/gitlab.go
+++ b/enterprise/internal/batches/webhooks/gitlab.go
@@ -128,7 +128,7 @@ func (h *GitLabWebhook) getExternalServiceFromRawID(ctx context.Context, raw str
 
 // handleEvent is essentially a router: it dispatches based on the event type
 // to perform whatever changeset action is appropriate for that event.
-func (h *GitLabWebhook) handleEvent(ctx context.Context, extSvc *types.ExternalService, event interface{}) *httpError {
+func (h *GitLabWebhook) handleEvent(ctx context.Context, extSvc *types.ExternalService, event any) *httpError {
 	log15.Debug("GitLab webhook received", "type", fmt.Sprintf("%T", event))
 
 	esID, err := extractExternalServiceID(extSvc)

--- a/enterprise/internal/batches/webhooks/gitlab_test.go
+++ b/enterprise/internal/batches/webhooks/gitlab_test.go
@@ -778,15 +778,15 @@ func TestValidateGitLabSecret(t *testing.T) {
 // error, the err field will be returned; otherwise nil will be returned.
 type brokenDB struct{ err error }
 
-func (db *brokenDB) QueryContext(ctx context.Context, q string, args ...interface{}) (*sql.Rows, error) {
+func (db *brokenDB) QueryContext(ctx context.Context, q string, args ...any) (*sql.Rows, error) {
 	return nil, db.err
 }
 
-func (db *brokenDB) ExecContext(ctx context.Context, q string, args ...interface{}) (sql.Result, error) {
+func (db *brokenDB) ExecContext(ctx context.Context, q string, args ...any) (sql.Result, error) {
 	return nil, db.err
 }
 
-func (db *brokenDB) QueryRowContext(ctx context.Context, q string, args ...interface{}) *sql.Row {
+func (db *brokenDB) QueryRowContext(ctx context.Context, q string, args ...any) *sql.Row {
 	return nil
 }
 
@@ -946,12 +946,12 @@ func createMergeRequestPayload(t *testing.T, repo *types.Repo, changeset *btypes
 	// We use an untyped set of maps here because the webhooks package doesn't
 	// export its internal mergeRequestEvent type that is used for
 	// unmarshalling. (Which is fine; it's an implementation detail.)
-	return ct.MarshalJSON(t, map[string]interface{}{
+	return ct.MarshalJSON(t, map[string]any{
 		"object_kind": "merge_request",
-		"project": map[string]interface{}{
+		"project": map[string]any{
 			"id": pid,
 		},
-		"object_attributes": map[string]interface{}{
+		"object_attributes": map[string]any{
 			"iid":    cid,
 			"action": action,
 		},

--- a/enterprise/internal/batches/webhooks/webhooks.go
+++ b/enterprise/internal/batches/webhooks/webhooks.go
@@ -189,7 +189,7 @@ func (e httpError) Error() string {
 	return fmt.Sprintf("HTTP %d: %s", e.code, http.StatusText(e.code))
 }
 
-func respond(w http.ResponseWriter, code int, v interface{}) {
+func respond(w http.ResponseWriter, code int, v any) {
 	switch val := v.(type) {
 	case nil:
 		w.WriteHeader(code)

--- a/enterprise/internal/codeintel/autoindex/enqueuer/mock_iface_test.go
+++ b/enterprise/internal/codeintel/autoindex/enqueuer/mock_iface_test.go
@@ -220,14 +220,14 @@ type DBStoreDirtyRepositoriesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreDirtyRepositoriesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c DBStoreDirtyRepositoriesFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreDirtyRepositoriesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreDirtyRepositoriesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreDoneFunc describes the behavior when the Done method of the parent
@@ -322,14 +322,14 @@ type DBStoreDoneFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreDoneFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c DBStoreDoneFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreDoneFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c DBStoreDoneFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // DBStoreGetIndexConfigurationByRepositoryIDFunc describes the behavior
@@ -439,14 +439,14 @@ type DBStoreGetIndexConfigurationByRepositoryIDFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreGetIndexConfigurationByRepositoryIDFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreGetIndexConfigurationByRepositoryIDFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreGetIndexConfigurationByRepositoryIDFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c DBStoreGetIndexConfigurationByRepositoryIDFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // DBStoreGetRepositoriesWithIndexConfigurationFunc describes the behavior
@@ -550,14 +550,14 @@ type DBStoreGetRepositoriesWithIndexConfigurationFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreGetRepositoriesWithIndexConfigurationFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c DBStoreGetRepositoriesWithIndexConfigurationFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreGetRepositoriesWithIndexConfigurationFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreGetRepositoriesWithIndexConfigurationFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreHandleFunc describes the behavior when the Handle method of the
@@ -649,14 +649,14 @@ type DBStoreHandleFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreHandleFuncCall) Args() []interface{} {
-	return []interface{}{}
+func (c DBStoreHandleFuncCall) Args() []any {
+	return []any{}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreHandleFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c DBStoreHandleFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // DBStoreInsertIndexFunc describes the behavior when the InsertIndex method
@@ -758,14 +758,14 @@ type DBStoreInsertIndexFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreInsertIndexFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DBStoreInsertIndexFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreInsertIndexFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreInsertIndexFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreIsQueuedFunc describes the behavior when the IsQueued method of
@@ -869,14 +869,14 @@ type DBStoreIsQueuedFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreIsQueuedFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c DBStoreIsQueuedFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreIsQueuedFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreIsQueuedFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DBStoreTransactFunc describes the behavior when the Transact method of
@@ -974,14 +974,14 @@ type DBStoreTransactFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DBStoreTransactFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c DBStoreTransactFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DBStoreTransactFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DBStoreTransactFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // MockGitserverClient is a mock implementation of the GitserverClient
@@ -1167,14 +1167,14 @@ type GitserverClientFileExistsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitserverClientFileExistsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c GitserverClientFileExistsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitserverClientFileExistsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c GitserverClientFileExistsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // GitserverClientHeadFunc describes the behavior when the Head method of
@@ -1279,14 +1279,14 @@ type GitserverClientHeadFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitserverClientHeadFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c GitserverClientHeadFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitserverClientHeadFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c GitserverClientHeadFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // GitserverClientListFilesFunc describes the behavior when the ListFiles
@@ -1394,14 +1394,14 @@ type GitserverClientListFilesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitserverClientListFilesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c GitserverClientListFilesFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitserverClientListFilesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c GitserverClientListFilesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // GitserverClientRawContentsFunc describes the behavior when the
@@ -1509,14 +1509,14 @@ type GitserverClientRawContentsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitserverClientRawContentsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c GitserverClientRawContentsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitserverClientRawContentsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c GitserverClientRawContentsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // GitserverClientResolveRevisionFunc describes the behavior when the
@@ -1623,14 +1623,14 @@ type GitserverClientResolveRevisionFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitserverClientResolveRevisionFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c GitserverClientResolveRevisionFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitserverClientResolveRevisionFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c GitserverClientResolveRevisionFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // MockRepoUpdaterClient is a mock implementation of the RepoUpdaterClient
@@ -1769,12 +1769,12 @@ type RepoUpdaterClientEnqueueRepoUpdateFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c RepoUpdaterClientEnqueueRepoUpdateFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c RepoUpdaterClientEnqueueRepoUpdateFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c RepoUpdaterClientEnqueueRepoUpdateFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c RepoUpdaterClientEnqueueRepoUpdateFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }

--- a/enterprise/internal/codeintel/stores/dbstore/commits.go
+++ b/enterprise/internal/codeintel/stores/dbstore/commits.go
@@ -711,9 +711,9 @@ func (s *uploadMetaListSerializer) take() []byte {
 }
 
 type sanitizedCommitInput struct {
-	nearestUploadsRowValues       <-chan []interface{}
-	nearestUploadsLinksRowValues  <-chan []interface{}
-	uploadsVisibleAtTipRowValues  <-chan []interface{}
+	nearestUploadsRowValues       <-chan []any
+	nearestUploadsLinksRowValues  <-chan []any
+	uploadsVisibleAtTipRowValues  <-chan []any
 	numNearestUploadsRecords      uint32 // populated once nearestUploadsRowValues is exhausted
 	numNearestUploadsLinksRecords uint32 // populated once nearestUploadsLinksRowValues is exhausted
 	numUploadsVisibleAtTipRecords uint32 // populated once uploadsVisibleAtTipRowValues is exhausted
@@ -734,9 +734,9 @@ func sanitizeCommitInput(
 		gitserver.RefTypeTag:    maxAgeForNonStaleTags,
 	}
 
-	nearestUploadsRowValues := make(chan []interface{})
-	nearestUploadsLinksRowValues := make(chan []interface{})
-	uploadsVisibleAtTipRowValues := make(chan []interface{})
+	nearestUploadsRowValues := make(chan []any)
+	nearestUploadsLinksRowValues := make(chan []any)
+	uploadsVisibleAtTipRowValues := make(chan []any)
 
 	sanitized := &sanitizedCommitInput{
 		nearestUploadsRowValues:      nearestUploadsRowValues,
@@ -810,7 +810,7 @@ func sanitizeCommitInput(
 // countingWrite writes the given slice of interfaces to the given channel. This function returns true
 // if the write succeeded and false if the context was canceled. On success, the counter's underlying
 // value will be incremented (non-atomically).
-func countingWrite(ctx context.Context, ch chan<- []interface{}, counter *uint32, values ...interface{}) bool {
+func countingWrite(ctx context.Context, ch chan<- []any, counter *uint32, values ...any) bool {
 	select {
 	case ch <- values:
 		*counter++

--- a/enterprise/internal/codeintel/stores/dbstore/docker_step.go
+++ b/enterprise/internal/codeintel/stores/dbstore/docker_step.go
@@ -13,7 +13,7 @@ type DockerStep struct {
 	Commands []string `json:"commands"`
 }
 
-func (s *DockerStep) Scan(value interface{}) error {
+func (s *DockerStep) Scan(value any) error {
 	b, ok := value.([]byte)
 	if !ok {
 		return errors.Errorf("value is not []byte: %T", value)

--- a/enterprise/internal/codeintel/stores/dbstore/migration/mock_iface.go
+++ b/enterprise/internal/codeintel/stores/dbstore/migration/mock_iface.go
@@ -144,12 +144,12 @@ type GitserverClientCommitDateFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitserverClientCommitDateFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c GitserverClientCommitDateFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitserverClientCommitDateFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c GitserverClientCommitDateFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }

--- a/enterprise/internal/codeintel/stores/dbstore/packages.go
+++ b/enterprise/internal/codeintel/stores/dbstore/packages.go
@@ -65,14 +65,14 @@ SELECT %s, source.scheme, source.name, source.version
 FROM t_lsif_packages source
 `
 
-func loadPackagesChannel(packages []semantic.Package) <-chan []interface{} {
-	ch := make(chan []interface{}, len(packages))
+func loadPackagesChannel(packages []semantic.Package) <-chan []any {
+	ch := make(chan []any, len(packages))
 
 	go func() {
 		defer close(ch)
 
 		for _, p := range packages {
-			ch <- []interface{}{p.Scheme, p.Name, p.Version}
+			ch <- []any{p.Scheme, p.Name, p.Version}
 		}
 	}()
 

--- a/enterprise/internal/codeintel/stores/dbstore/references.go
+++ b/enterprise/internal/codeintel/stores/dbstore/references.go
@@ -66,8 +66,8 @@ SELECT %s, source.scheme, source.name, source.version, source.filter
 FROM t_lsif_references source
 `
 
-func loadReferencesChannel(references []semantic.PackageReference) <-chan []interface{} {
-	ch := make(chan []interface{}, len(references))
+func loadReferencesChannel(references []semantic.PackageReference) <-chan []any {
+	ch := make(chan []any, len(references))
 
 	go func() {
 		defer close(ch)
@@ -79,7 +79,7 @@ func loadReferencesChannel(references []semantic.PackageReference) <-chan []inte
 				filter = []byte{}
 			}
 
-			ch <- []interface{}{r.Scheme, r.Name, r.Version, filter}
+			ch <- []any{r.Scheme, r.Name, r.Version, filter}
 		}
 	}()
 

--- a/enterprise/internal/codeintel/stores/lsifstore/migration/diagnostics_count.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/migration/diagnostics_count.go
@@ -31,7 +31,7 @@ func NewDiagnosticsCountMigrator(store *lsifstore.Store, batchSize int) oobmigra
 
 // MigrateRowUp reads the payload of the given row and returns an updateSpec on how to
 // modify the record to conform to the new schema.
-func (m *diagnosticsCountMigrator) MigrateRowUp(scanner scanner) ([]interface{}, error) {
+func (m *diagnosticsCountMigrator) MigrateRowUp(scanner scanner) ([]any, error) {
 	var path string
 	var rawData []byte
 
@@ -44,11 +44,11 @@ func (m *diagnosticsCountMigrator) MigrateRowUp(scanner scanner) ([]interface{},
 		return nil, err
 	}
 
-	return []interface{}{path, len(data.Diagnostics)}, nil
+	return []any{path, len(data.Diagnostics)}, nil
 }
 
 // MigrateRowDown sets num_diagnostics back to zero to undo the migration up direction.
-func (m *diagnosticsCountMigrator) MigrateRowDown(scanner scanner) ([]interface{}, error) {
+func (m *diagnosticsCountMigrator) MigrateRowDown(scanner scanner) ([]any, error) {
 	var path string
 	var rawData []byte
 
@@ -56,5 +56,5 @@ func (m *diagnosticsCountMigrator) MigrateRowDown(scanner scanner) ([]interface{
 		return nil, err
 	}
 
-	return []interface{}{path, 0}, nil
+	return []any{path, 0}, nil
 }

--- a/enterprise/internal/codeintel/stores/lsifstore/migration/document_column_split.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/migration/document_column_split.go
@@ -36,7 +36,7 @@ func NewDocumentColumnSplitMigrator(store *lsifstore.Store, batchSize int) oobmi
 
 // MigrateRowUp reads the payload of the given row and returns an updateSpec on how to
 // modify the record to conform to the new schema.
-func (m *documentColumnSplitMigrator) MigrateRowUp(scanner scanner) ([]interface{}, error) {
+func (m *documentColumnSplitMigrator) MigrateRowUp(scanner scanner) ([]any, error) {
 	var path string
 	var rawData, ignored []byte
 
@@ -61,7 +61,7 @@ func (m *documentColumnSplitMigrator) MigrateRowUp(scanner scanner) ([]interface
 		return nil, err
 	}
 
-	return []interface{}{
+	return []any{
 		path,
 		nil,                        // data
 		encoded.Ranges,             // ranges
@@ -73,7 +73,7 @@ func (m *documentColumnSplitMigrator) MigrateRowUp(scanner scanner) ([]interface
 }
 
 // MigrateRowDown sets num_diagnostics back to zero to undo the migration up direction.
-func (m *documentColumnSplitMigrator) MigrateRowDown(scanner scanner) ([]interface{}, error) {
+func (m *documentColumnSplitMigrator) MigrateRowDown(scanner scanner) ([]any, error) {
 	var path string
 	var rawData []byte
 	var encoded lsifstore.MarshalledDocumentData
@@ -99,7 +99,7 @@ func (m *documentColumnSplitMigrator) MigrateRowDown(scanner scanner) ([]interfa
 		return nil, err
 	}
 
-	return []interface{}{
+	return []any{
 		path,
 		reencoded, // data
 		nil,       // ranges

--- a/enterprise/internal/codeintel/stores/lsifstore/migration/locations_count.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/migration/locations_count.go
@@ -32,7 +32,7 @@ func NewLocationsCountMigrator(store *lsifstore.Store, tableName string, batchSi
 
 // MigrateRowUp reads the payload of the given row and returns an updateSpec on how to
 // modify the record to conform to the new schema.
-func (m *locationsCountMigrator) MigrateRowUp(scanner scanner) ([]interface{}, error) {
+func (m *locationsCountMigrator) MigrateRowUp(scanner scanner) ([]any, error) {
 	var scheme, identifier string
 	var rawData []byte
 
@@ -45,11 +45,11 @@ func (m *locationsCountMigrator) MigrateRowUp(scanner scanner) ([]interface{}, e
 		return nil, err
 	}
 
-	return []interface{}{scheme, identifier, len(data)}, nil
+	return []any{scheme, identifier, len(data)}, nil
 }
 
 // MigrateRowDown sets num_locations back to zero to undo the migration up direction.
-func (m *locationsCountMigrator) MigrateRowDown(scanner scanner) ([]interface{}, error) {
+func (m *locationsCountMigrator) MigrateRowDown(scanner scanner) ([]any, error) {
 	var scheme, identifier string
 	var rawData []byte
 
@@ -57,5 +57,5 @@ func (m *locationsCountMigrator) MigrateRowDown(scanner scanner) ([]interface{},
 		return nil, err
 	}
 
-	return []interface{}{scheme, identifier, 0}, nil
+	return []any{scheme, identifier, 0}, nil
 }

--- a/enterprise/internal/codeintel/stores/lsifstore/migration/migrator.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/migration/migrator.go
@@ -22,16 +22,18 @@ import (
 //
 // We have the following assumptions about the schema (for a configured table T):
 //
-// 1. There is an index on T.dump_id
-// 2. For each distinct dump_id in table T, there is a corresponding row in table
-//    T_schema_version. This invariant is kept up to date via triggers on insert.
-// 3. Table T_schema_version has the following schema:
+//  1. There is an index on T.dump_id
 //
-//    CREATE TABLE T_schema_versions (
-//        dump_id            integer PRIMARY KEY NOT NULL,
-//        min_schema_version integer,
-//        max_schema_version integer
-//    );
+//  2. For each distinct dump_id in table T, there is a corresponding row in table
+//     T_schema_version. This invariant is kept up to date via triggers on insert.
+//
+//  3. Table T_schema_version has the following schema:
+//
+//     CREATE TABLE T_schema_versions (
+//     dump_id            integer PRIMARY KEY NOT NULL,
+//     min_schema_version integer,
+//     max_schema_version integer
+//     );
 //
 // When selecting a set of candidate records to migrate, we first use the each upload record's
 // schema version bounds to determine if there are still records associated with that upload
@@ -88,20 +90,20 @@ type migrationDriver interface {
 	// migrator's fields option. Implementations must return the same number of values as the set
 	// of primary keys plus any additional non-selectOnly fields supplied via the migrator's fields
 	// option.
-	MigrateRowUp(scanner scanner) ([]interface{}, error)
+	MigrateRowUp(scanner scanner) ([]any, error)
 
 	// MigrateRowDown undoes the migration for the given row.  The scanner will receive the values
 	// of the primary keys plus any additional non-updateOnly fields supplied via the migrator's
 	// fields option. Implementations must return the same number of values as the set  of primary
 	// keys plus any additional non-selectOnly fields supplied via the migrator's fields option.
-	MigrateRowDown(scanner scanner) ([]interface{}, error)
+	MigrateRowDown(scanner scanner) ([]any, error)
 }
 
 // driverFunc is the type of MigrateRowUp and MigrateRowDown.
-type driverFunc func(scanner scanner) ([]interface{}, error)
+type driverFunc func(scanner scanner) ([]any, error)
 
 type scanner interface {
-	Scan(dest ...interface{}) error
+	Scan(dest ...any) error
 }
 
 func newMigrator(store *lsifstore.Store, driver migrationDriver, options migratorOptions) oobmigration.Migrator {
@@ -313,7 +315,7 @@ FOR UPDATE SKIP LOCKED
 // processRows selects a batch of rows from the target table associated with the given dump identifier
 // to  update and calls the given driver func over each row. The driver func returns the set of values
 // that should be used to update that row. These values are fed into a channel usable for batch insert.
-func (m *Migrator) processRows(ctx context.Context, tx *lsifstore.Store, dumpID, version int, driverFunc driverFunc) (_ <-chan []interface{}, err error) {
+func (m *Migrator) processRows(ctx context.Context, tx *lsifstore.Store, dumpID, version int, driverFunc driverFunc) (_ <-chan []any, err error) {
 	rows, err := tx.Query(ctx, sqlf.Sprintf(
 		processRowsQuery,
 		sqlf.Join(m.selectionExpressions, ", "),
@@ -327,7 +329,7 @@ func (m *Migrator) processRows(ctx context.Context, tx *lsifstore.Store, dumpID,
 	}
 	defer func() { err = basestore.CloseRows(rows, err) }()
 
-	rowValues := make(chan []interface{}, m.options.batchSize)
+	rowValues := make(chan []any, m.options.batchSize)
 	defer close(rowValues)
 
 	for rows.Next() {
@@ -353,7 +355,7 @@ var temporaryTableExpression = sqlf.Sprintf(temporaryTableName)
 // updateBatch creates a temporary table symmetric to the target table but without any of the read-only
 // fields. Then, the given row values are bulk inserted into the temporary table. Finally, the rows in
 // the temporary table are used to update the target table.
-func (m *Migrator) updateBatch(ctx context.Context, tx *lsifstore.Store, dumpID, targetVersion int, rowValues <-chan []interface{}) error {
+func (m *Migrator) updateBatch(ctx context.Context, tx *lsifstore.Store, dumpID, targetVersion int, rowValues <-chan []any) error {
 	if err := tx.Exec(ctx, sqlf.Sprintf(
 		updateBatchTemporaryTableQuery,
 		temporaryTableExpression,

--- a/enterprise/internal/codeintel/stores/lsifstore/migration/migrator_test.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/migration/migrator_test.go
@@ -122,20 +122,20 @@ func TestMigratorRemovesBoundsWithoutData(t *testing.T) {
 
 type testMigrationDriver struct{}
 
-func (m *testMigrationDriver) MigrateRowUp(scanner scanner) ([]interface{}, error) {
+func (m *testMigrationDriver) MigrateRowUp(scanner scanner) ([]any, error) {
 	var a, b, c int
 	if err := scanner.Scan(&a, &b, &c); err != nil {
 		return nil, err
 	}
 
-	return []interface{}{a, b + c}, nil
+	return []any{a, b + c}, nil
 }
 
-func (m *testMigrationDriver) MigrateRowDown(scanner scanner) ([]interface{}, error) {
+func (m *testMigrationDriver) MigrateRowDown(scanner scanner) ([]any, error) {
 	var a, b, c int
 	if err := scanner.Scan(&a, &b, &c); err != nil {
 		return nil, err
 	}
 
-	return []interface{}{a, b - c}, nil
+	return []any{a, b - c}, nil
 }

--- a/enterprise/internal/codeintel/stores/lsifstore/serializer.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/serializer.go
@@ -25,8 +25,8 @@ type Serializer struct {
 
 func NewSerializer() *Serializer {
 	return &Serializer{
-		readers: sync.Pool{New: func() interface{} { return new(gzip.Reader) }},
-		writers: sync.Pool{New: func() interface{} { return gzip.NewWriter(nil) }},
+		readers: sync.Pool{New: func() any { return new(gzip.Reader) }},
+		writers: sync.Pool{New: func() any { return gzip.NewWriter(nil) }},
 	}
 }
 
@@ -76,7 +76,7 @@ func (s *Serializer) MarshalLocations(locations []semantic.LocationData) ([]byte
 }
 
 // encode gob-encodes and compresses the given payload.
-func (s *Serializer) encode(payload interface{}) (_ []byte, err error) {
+func (s *Serializer) encode(payload any) (_ []byte, err error) {
 	gzipWriter := s.writers.Get().(*gzip.Writer)
 	defer s.writers.Put(gzipWriter)
 
@@ -139,7 +139,7 @@ func (s *Serializer) UnmarshalLocations(data []byte) (locations []semantic.Locat
 
 // encode decompresses gob-decodes the given data and sets the given pointer. If the given data
 // is empty, the pointer will not be assigned.
-func (s *Serializer) decode(data []byte, target interface{}) (err error) {
+func (s *Serializer) decode(data []byte, target any) (err error) {
 	if len(data) == 0 {
 		return nil
 	}

--- a/enterprise/internal/codeintel/stores/uploadstore/mock_gcs_api_test.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/mock_gcs_api_test.go
@@ -141,14 +141,14 @@ type GcsAPIBucketFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GcsAPIBucketFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c GcsAPIBucketFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GcsAPIBucketFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c GcsAPIBucketFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // MockGcsBucketHandle is a mock implementation of the gcsBucketHandle
@@ -325,14 +325,14 @@ type GcsBucketHandleAttrsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GcsBucketHandleAttrsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c GcsBucketHandleAttrsFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GcsBucketHandleAttrsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c GcsBucketHandleAttrsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // GcsBucketHandleCreateFunc describes the behavior when the Create method
@@ -434,14 +434,14 @@ type GcsBucketHandleCreateFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GcsBucketHandleCreateFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c GcsBucketHandleCreateFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GcsBucketHandleCreateFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c GcsBucketHandleCreateFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // GcsBucketHandleObjectFunc describes the behavior when the Object method
@@ -537,14 +537,14 @@ type GcsBucketHandleObjectFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GcsBucketHandleObjectFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c GcsBucketHandleObjectFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GcsBucketHandleObjectFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c GcsBucketHandleObjectFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // GcsBucketHandleUpdateFunc describes the behavior when the Update method
@@ -643,14 +643,14 @@ type GcsBucketHandleUpdateFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GcsBucketHandleUpdateFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c GcsBucketHandleUpdateFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GcsBucketHandleUpdateFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c GcsBucketHandleUpdateFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // MockGcsComposer is a mock implementation of the gcsComposer interface
@@ -789,14 +789,14 @@ type GcsComposerRunFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GcsComposerRunFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c GcsComposerRunFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GcsComposerRunFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c GcsComposerRunFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // MockGcsObjectHandle is a mock implementation of the gcsObjectHandle
@@ -973,19 +973,19 @@ type GcsObjectHandleComposerFromFuncCall struct {
 // invocation. The variadic slice argument is flattened in this array such
 // that one positional argument and three variadic arguments would result in
 // a slice of four, not two.
-func (c GcsObjectHandleComposerFromFuncCall) Args() []interface{} {
-	trailing := []interface{}{}
+func (c GcsObjectHandleComposerFromFuncCall) Args() []any {
+	trailing := []any{}
 	for _, val := range c.Arg0 {
 		trailing = append(trailing, val)
 	}
 
-	return append([]interface{}{}, trailing...)
+	return append([]any{}, trailing...)
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GcsObjectHandleComposerFromFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c GcsObjectHandleComposerFromFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // GcsObjectHandleDeleteFunc describes the behavior when the Delete method
@@ -1081,14 +1081,14 @@ type GcsObjectHandleDeleteFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GcsObjectHandleDeleteFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c GcsObjectHandleDeleteFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GcsObjectHandleDeleteFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c GcsObjectHandleDeleteFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // GcsObjectHandleNewRangeReaderFunc describes the behavior when the
@@ -1195,14 +1195,14 @@ type GcsObjectHandleNewRangeReaderFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GcsObjectHandleNewRangeReaderFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c GcsObjectHandleNewRangeReaderFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GcsObjectHandleNewRangeReaderFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c GcsObjectHandleNewRangeReaderFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // GcsObjectHandleNewWriterFunc describes the behavior when the NewWriter
@@ -1298,12 +1298,12 @@ type GcsObjectHandleNewWriterFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GcsObjectHandleNewWriterFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c GcsObjectHandleNewWriterFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GcsObjectHandleNewWriterFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c GcsObjectHandleNewWriterFuncCall) Results() []any {
+	return []any{c.Result0}
 }

--- a/enterprise/internal/codeintel/stores/uploadstore/mock_s3_api_test.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/mock_s3_api_test.go
@@ -244,14 +244,14 @@ type S3APIAbortMultipartUploadFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c S3APIAbortMultipartUploadFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c S3APIAbortMultipartUploadFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c S3APIAbortMultipartUploadFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c S3APIAbortMultipartUploadFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // S3APICompleteMultipartUploadFunc describes the behavior when the
@@ -354,14 +354,14 @@ type S3APICompleteMultipartUploadFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c S3APICompleteMultipartUploadFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c S3APICompleteMultipartUploadFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c S3APICompleteMultipartUploadFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c S3APICompleteMultipartUploadFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // S3APICreateBucketFunc describes the behavior when the CreateBucket method
@@ -462,14 +462,14 @@ type S3APICreateBucketFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c S3APICreateBucketFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c S3APICreateBucketFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c S3APICreateBucketFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c S3APICreateBucketFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // S3APICreateMultipartUploadFunc describes the behavior when the
@@ -571,14 +571,14 @@ type S3APICreateMultipartUploadFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c S3APICreateMultipartUploadFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c S3APICreateMultipartUploadFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c S3APICreateMultipartUploadFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c S3APICreateMultipartUploadFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // S3APIDeleteObjectFunc describes the behavior when the DeleteObject method
@@ -679,14 +679,14 @@ type S3APIDeleteObjectFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c S3APIDeleteObjectFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c S3APIDeleteObjectFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c S3APIDeleteObjectFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c S3APIDeleteObjectFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // S3APIGetObjectFunc describes the behavior when the GetObject method of
@@ -787,14 +787,14 @@ type S3APIGetObjectFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c S3APIGetObjectFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c S3APIGetObjectFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c S3APIGetObjectFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c S3APIGetObjectFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // S3APIHeadObjectFunc describes the behavior when the HeadObject method of
@@ -895,14 +895,14 @@ type S3APIHeadObjectFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c S3APIHeadObjectFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c S3APIHeadObjectFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c S3APIHeadObjectFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c S3APIHeadObjectFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // S3APIPutBucketLifecycleConfigurationFunc describes the behavior when the
@@ -1008,14 +1008,14 @@ type S3APIPutBucketLifecycleConfigurationFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c S3APIPutBucketLifecycleConfigurationFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c S3APIPutBucketLifecycleConfigurationFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c S3APIPutBucketLifecycleConfigurationFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c S3APIPutBucketLifecycleConfigurationFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // S3APIUploadPartCopyFunc describes the behavior when the UploadPartCopy
@@ -1117,14 +1117,14 @@ type S3APIUploadPartCopyFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c S3APIUploadPartCopyFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c S3APIUploadPartCopyFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c S3APIUploadPartCopyFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c S3APIUploadPartCopyFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // MockS3Uploader is a mock implementation of the s3Uploader interface (from
@@ -1262,12 +1262,12 @@ type S3UploaderUploadFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c S3UploaderUploadFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c S3UploaderUploadFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c S3UploaderUploadFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c S3UploaderUploadFuncCall) Results() []any {
+	return []any{c.Result0}
 }

--- a/enterprise/internal/codeintel/stores/uploadstore/mocks/mock_store.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/mocks/mock_store.go
@@ -189,19 +189,19 @@ type StoreComposeFuncCall struct {
 // invocation. The variadic slice argument is flattened in this array such
 // that one positional argument and three variadic arguments would result in
 // a slice of four, not two.
-func (c StoreComposeFuncCall) Args() []interface{} {
-	trailing := []interface{}{}
+func (c StoreComposeFuncCall) Args() []any {
+	trailing := []any{}
 	for _, val := range c.Arg2 {
 		trailing = append(trailing, val)
 	}
 
-	return append([]interface{}{c.Arg0, c.Arg1}, trailing...)
+	return append([]any{c.Arg0, c.Arg1}, trailing...)
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreComposeFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c StoreComposeFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // StoreDeleteFunc describes the behavior when the Delete method of the
@@ -299,14 +299,14 @@ type StoreDeleteFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreDeleteFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c StoreDeleteFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreDeleteFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c StoreDeleteFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // StoreGetFunc describes the behavior when the Get method of the parent
@@ -407,14 +407,14 @@ type StoreGetFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreGetFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c StoreGetFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreGetFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c StoreGetFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // StoreInitFunc describes the behavior when the Init method of the parent
@@ -509,14 +509,14 @@ type StoreInitFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreInitFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c StoreInitFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreInitFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c StoreInitFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // StoreUploadFunc describes the behavior when the Upload method of the
@@ -620,12 +620,12 @@ type StoreUploadFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreUploadFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c StoreUploadFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreUploadFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c StoreUploadFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }

--- a/enterprise/internal/codemonitors/background/graphql.go
+++ b/enterprise/internal/codemonitors/background/graphql.go
@@ -17,8 +17,8 @@ import (
 )
 
 type graphQLQuery struct {
-	Query     string      `json:"query"`
-	Variables interface{} `json:"variables"`
+	Query     string `json:"query"`
+	Variables any    `json:"variables"`
 }
 
 const gqlSearchQuery = `query Search(
@@ -113,11 +113,11 @@ type gqlSearchResponse struct {
 				ApproximateResultCount string
 				Cloning                []*api.Repo
 				Timedout               []*api.Repo
-				Results                []interface{}
+				Results                []any
 			}
 		}
 	}
-	Errors []interface{}
+	Errors []any
 }
 
 func search(ctx context.Context, query string) (*gqlSearchResponse, error) {
@@ -162,7 +162,7 @@ func gqlURL(queryName string) (string, error) {
 }
 
 // extractTime extracts the time from the given search result.
-func extractTime(result interface{}) (t *time.Time, err error) {
+func extractTime(result any) (t *time.Time, err error) {
 	// Use recover because we assume the data structure here a lot, for less
 	// error checking.
 	defer func() {
@@ -176,12 +176,12 @@ func extractTime(result interface{}) (t *time.Time, err error) {
 		}
 	}()
 
-	m := result.(map[string]interface{})
+	m := result.(map[string]any)
 	typeName := m["__typename"].(string)
 	switch typeName {
 	case "CommitSearchResult":
-		commit := m["commit"].(map[string]interface{})
-		author := commit["author"].(map[string]interface{})
+		commit := m["commit"].(map[string]any)
+		author := commit["author"].(map[string]any)
 		date := author["date"].(string)
 
 		// This relies on the date format that our API returns. It was previously broken

--- a/enterprise/internal/codemonitors/email/email.go
+++ b/enterprise/internal/codemonitors/email/email.go
@@ -87,7 +87,7 @@ func NewTestTemplateDataForNewSearchResults(ctx context.Context, monitorDescript
 	}
 }
 
-func sendEmail(ctx context.Context, userID int32, template txtypes.Templates, data interface{}) error {
+func sendEmail(ctx context.Context, userID int32, template txtypes.Templates, data any) error {
 	email, err := api.InternalClient.UserEmailsGetEmail(ctx, userID)
 	if err != nil {
 		return errors.Errorf("InternalClient.UserEmailsGetEmail for userID=%d: %w", userID, err)

--- a/enterprise/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers_test.go
@@ -415,7 +415,7 @@ func TestQueryMonitor(t *testing.T) {
 }
 
 func queryByUser(ctx context.Context, t *testing.T, schema *graphql.Schema, r *Resolver, user1 *testUser, user2 *testUser) {
-	input := map[string]interface{}{
+	input := map[string]any{
 		"userName":     user1.name,
 		"actionCursor": relay.MarshalID(monitorActionEventKind, 1),
 	}
@@ -626,7 +626,7 @@ func TestEditCodeMonitor(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	updateInput := map[string]interface{}{
+	updateInput := map[string]any{
 		"monitorID": string(relay.MarshalID(MonitorKind, 1)),
 		"triggerID": string(relay.MarshalID(monitorTriggerQueryKind, 1)),
 		"actionID":  string(relay.MarshalID(monitorActionEmailKind, 1)),
@@ -759,7 +759,7 @@ mutation ($monitorID: ID!, $triggerID: ID!, $actionID: ID!, $user1ID: ID!, $user
 `
 
 func recipientPaging(ctx context.Context, t *testing.T, schema *graphql.Schema, user1 *testUser, user2 *testUser) {
-	queryInput := map[string]interface{}{
+	queryInput := map[string]any{
 		"userName":        user1.name,
 		"recipientCursor": string(relay.MarshalID(monitorActionEmailRecipientKind, 1)),
 	}
@@ -821,7 +821,7 @@ query($userName: String!, $recipientCursor: String!){
 `
 
 func queryByID(ctx context.Context, t *testing.T, schema *graphql.Schema, r *Resolver, m *monitor, user1 *testUser, user2 *testUser) {
-	input := map[string]interface{}{
+	input := map[string]any{
 		"id": m.ID(),
 	}
 	response := apitest.Node{}
@@ -945,7 +945,7 @@ query ($id: ID!) {
 `
 
 func monitorPaging(ctx context.Context, t *testing.T, schema *graphql.Schema, user1 *testUser) {
-	queryInput := map[string]interface{}{
+	queryInput := map[string]any{
 		"userName":      user1.name,
 		"monitorCursor": string(relay.MarshalID(MonitorKind, 1)),
 	}
@@ -982,7 +982,7 @@ query($userName: String!, $monitorCursor: String!){
 `
 
 func actionPaging(ctx context.Context, t *testing.T, schema *graphql.Schema, user1 *testUser) {
-	queryInput := map[string]interface{}{
+	queryInput := map[string]any{
 		"userName":     user1.name,
 		"actionCursor": string(relay.MarshalID(monitorActionEmailKind, 1)),
 	}
@@ -1033,7 +1033,7 @@ query($userName: String!, $actionCursor:String!){
 `
 
 func triggerEventPaging(ctx context.Context, t *testing.T, schema *graphql.Schema, user1 *testUser) {
-	queryInput := map[string]interface{}{
+	queryInput := map[string]any{
 		"userName":           user1.name,
 		"triggerEventCursor": relay.MarshalID(monitorTriggerEventKind, 1),
 	}
@@ -1086,7 +1086,7 @@ query($userName: String!, $triggerEventCursor: String!){
 `
 
 func actionEventPaging(ctx context.Context, t *testing.T, schema *graphql.Schema, user1 *testUser) {
-	queryInput := map[string]interface{}{
+	queryInput := map[string]any{
 		"userName":          user1.name,
 		"actionCursor":      string(relay.MarshalID(monitorActionEmailKind, 1)),
 		"actionEventCursor": relay.MarshalID(monitorActionEventKind, 1),

--- a/enterprise/internal/database/db_test.go
+++ b/enterprise/internal/database/db_test.go
@@ -12,7 +12,7 @@ func init() {
 	dbtesting.DBNameSuffix = "enterprisedb"
 }
 
-func equal(t testing.TB, name string, want, have interface{}) {
+func equal(t testing.TB, name string, want, have any) {
 	t.Helper()
 	if diff := cmp.Diff(want, have); diff != "" {
 		t.Fatalf("%q: %s", name, diff)

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -144,24 +144,26 @@ AND permission = %s
 // and `repo_permissions` tables.
 //
 // Example input:
-// &UserPermissions{
-//     UserID: 1,
-//     Perm: authz.Read,
-//     Type: authz.PermRepos,
-//     IDs: bitmap{1, 2},
-// }
+//
+//	&UserPermissions{
+//	    UserID: 1,
+//	    Perm: authz.Read,
+//	    Type: authz.PermRepos,
+//	    IDs: bitmap{1, 2},
+//	}
 //
 // Table states for input:
-// 	"user_permissions":
-//   user_id | permission | object_type | object_ids_ints | updated_at | synced_at
-//  ---------+------------+-------------+-----------------+------------+-----------
-//         1 |       read |       repos |          {1, 2} |      NOW() |     NOW()
 //
-//  "repo_permissions":
-//   repo_id | permission | user_ids_ints | updated_at |  synced_at
-//  ---------+------------+---------------+------------+-------------
-//         1 |       read |           {1} |      NOW() | <Unchanged>
-//         2 |       read |           {1} |      NOW() | <Unchanged>
+//		"user_permissions":
+//	  user_id | permission | object_type | object_ids_ints | updated_at | synced_at
+//	 ---------+------------+-------------+-----------------+------------+-----------
+//	        1 |       read |       repos |          {1, 2} |      NOW() |     NOW()
+//
+//	 "repo_permissions":
+//	  repo_id | permission | user_ids_ints | updated_at |  synced_at
+//	 ---------+------------+---------------+------------+-------------
+//	        1 |       read |           {1} |      NOW() | <Unchanged>
+//	        2 |       read |           {1} |      NOW() | <Unchanged>
 func (s *PermsStore) SetUserPermissions(ctx context.Context, p *authz.UserPermissions) (err error) {
 	if Mocks.Perms.SetUserPermissions != nil {
 		return Mocks.Perms.SetUserPermissions(ctx, p)
@@ -264,23 +266,25 @@ DO UPDATE SET
 // This method starts its own transaction for update consistency if the caller hasn't started one already.
 //
 // Example input:
-// &RepoPermissions{
-//     RepoID: 1,
-//     Perm: authz.Read,
-//     UserIDs: bitmap{1, 2},
-// }
+//
+//	&RepoPermissions{
+//	    RepoID: 1,
+//	    Perm: authz.Read,
+//	    UserIDs: bitmap{1, 2},
+//	}
 //
 // Table states for input:
-// 	"user_permissions":
-//   user_id | permission | object_type | object_ids_ints | updated_at |  synced_at
-//  ---------+------------+-------------+-----------------+------------+-------------
-//         1 |       read |       repos |             {1} |      NOW() | <Unchanged>
-//         2 |       read |       repos |             {1} |      NOW() | <Unchanged>
 //
-//  "repo_permissions":
-//   repo_id | permission | user_ids_ints | updated_at | synced_at
-//  ---------+------------+---------------+------------+-----------
-//         1 |       read |        {1, 2} |      NOW() |     NOW()
+//		"user_permissions":
+//	  user_id | permission | object_type | object_ids_ints | updated_at |  synced_at
+//	 ---------+------------+-------------+-----------------+------------+-------------
+//	        1 |       read |       repos |             {1} |      NOW() | <Unchanged>
+//	        2 |       read |       repos |             {1} |      NOW() | <Unchanged>
+//
+//	 "repo_permissions":
+//	  repo_id | permission | user_ids_ints | updated_at | synced_at
+//	 ---------+------------+---------------+------------+-----------
+//	        1 |       read |        {1, 2} |      NOW() |     NOW()
 func (s *PermsStore) SetRepoPermissions(ctx context.Context, p *authz.RepoPermissions) (err error) {
 	if Mocks.Perms.SetRepoPermissions != nil {
 		return Mocks.Perms.SetRepoPermissions(ctx, p)
@@ -521,27 +525,29 @@ AND bind_id = %s
 // This method starts its own transaction for update consistency if the caller hasn't started one already.
 //
 // Example input:
-//  &extsvc.Accounts{
-//      ServiceType: "sourcegraph",
-//      ServiceID:   "https://sourcegraph.com/",
-//      AccountIDs:  []string{"alice", "bob"},
-//  }
-//  &authz.RepoPermissions{
-//      RepoID: 1,
-//      Perm: authz.Read,
-//  }
+//
+//	&extsvc.Accounts{
+//	    ServiceType: "sourcegraph",
+//	    ServiceID:   "https://sourcegraph.com/",
+//	    AccountIDs:  []string{"alice", "bob"},
+//	}
+//	&authz.RepoPermissions{
+//	    RepoID: 1,
+//	    Perm: authz.Read,
+//	}
 //
 // Table states for input:
-// 	"user_pending_permissions":
-//   id | service_type |        service_id        | bind_id | permission | object_type | object_ids_ints | updated_at
-//  ----+--------------+--------------------------+---------+------------+-------------+-----------------+-----------
-//    1 | sourcegraph  | https://sourcegraph.com/ |   alice |       read |       repos |             {1} | <DateTime>
-//    2 | sourcegraph  | https://sourcegraph.com/ |     bob |       read |       repos |             {1} | <DateTime>
 //
-//  "repo_pending_permissions":
-//   repo_id | permission | user_ids_ints | updated_at
-//  ---------+------------+---------------+------------
-//         1 |       read |        {1, 2} | <DateTime>
+//		"user_pending_permissions":
+//	  id | service_type |        service_id        | bind_id | permission | object_type | object_ids_ints | updated_at
+//	 ----+--------------+--------------------------+---------+------------+-------------+-----------------+-----------
+//	   1 | sourcegraph  | https://sourcegraph.com/ |   alice |       read |       repos |             {1} | <DateTime>
+//	   2 | sourcegraph  | https://sourcegraph.com/ |     bob |       read |       repos |             {1} | <DateTime>
+//
+//	 "repo_pending_permissions":
+//	  repo_id | permission | user_ids_ints | updated_at
+//	 ---------+------------+---------------+------------
+//	        1 |       read |        {1, 2} | <DateTime>
 func (s *PermsStore) SetRepoPendingPermissions(ctx context.Context, accounts *extsvc.Accounts, p *authz.RepoPermissions) (err error) {
 	if Mocks.Perms.SetRepoPendingPermissions != nil {
 		return Mocks.Perms.SetRepoPendingPermissions(ctx, accounts, p)
@@ -1016,7 +1022,7 @@ AND bind_id IN (%s)`,
 	return nil
 }
 
-func (s *PermsStore) execute(ctx context.Context, q *sqlf.Query, vs ...interface{}) (err error) {
+func (s *PermsStore) execute(ctx context.Context, q *sqlf.Query, vs ...any) (err error) {
 	ctx, save := s.observe(ctx, "execute", "")
 	defer func() { save(&err, otlog.Object("q", q)) }()
 

--- a/enterprise/internal/insights/background/mock_repo_store.go
+++ b/enterprise/internal/insights/background/mock_repo_store.go
@@ -140,12 +140,12 @@ type RepoStoreGetByNameFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c RepoStoreGetByNameFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c RepoStoreGetByNameFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c RepoStoreGetByNameFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c RepoStoreGetByNameFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }

--- a/enterprise/internal/insights/background/queryrunner/graphql.go
+++ b/enterprise/internal/insights/background/queryrunner/graphql.go
@@ -18,8 +18,8 @@ import (
 
 // graphQLQuery describes a general GraphQL query and its variables.
 type graphQLQuery struct {
-	Query     string      `json:"query"`
-	Variables interface{} `json:"variables"`
+	Query     string `json:"query"`
+	Variables any    `json:"variables"`
 }
 
 const gqlSearchQuery = `query Search(
@@ -90,7 +90,7 @@ type gqlSearchResponse struct {
 			}
 		}
 	}
-	Errors []interface{}
+	Errors []any
 }
 
 // search executes the given search query.

--- a/enterprise/internal/insights/compression/mock_commit_store.go
+++ b/enterprise/internal/insights/compression/mock_commit_store.go
@@ -192,14 +192,14 @@ type CommitStoreGetFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c CommitStoreGetFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c CommitStoreGetFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c CommitStoreGetFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c CommitStoreGetFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // CommitStoreGetMetadataFunc describes the behavior when the GetMetadata
@@ -301,14 +301,14 @@ type CommitStoreGetMetadataFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c CommitStoreGetMetadataFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c CommitStoreGetMetadataFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c CommitStoreGetMetadataFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c CommitStoreGetMetadataFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // CommitStoreInsertCommitsFunc describes the behavior when the
@@ -410,14 +410,14 @@ type CommitStoreInsertCommitsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c CommitStoreInsertCommitsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c CommitStoreInsertCommitsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c CommitStoreInsertCommitsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c CommitStoreInsertCommitsFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // CommitStoreSaveFunc describes the behavior when the Save method of the
@@ -518,14 +518,14 @@ type CommitStoreSaveFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c CommitStoreSaveFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c CommitStoreSaveFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c CommitStoreSaveFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c CommitStoreSaveFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // CommitStoreUpsertMetadataStampFunc describes the behavior when the
@@ -629,12 +629,12 @@ type CommitStoreUpsertMetadataStampFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c CommitStoreUpsertMetadataStampFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c CommitStoreUpsertMetadataStampFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c CommitStoreUpsertMetadataStampFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c CommitStoreUpsertMetadataStampFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }

--- a/enterprise/internal/insights/discovery/discovery_test.go
+++ b/enterprise/internal/insights/discovery/discovery_test.go
@@ -163,19 +163,19 @@ func Test_parseUserSettings(t *testing.T) {
 		{
 			name:  "nil",
 			input: nil,
-			want:  autogold.Want("nil", [2]interface{}{&schema.Settings{}, nil}),
+			want:  autogold.Want("nil", [2]any{&schema.Settings{}, nil}),
 		},
 		{
 			name: "empty",
 			input: &api.Settings{
 				Contents: "{}",
 			},
-			want: autogold.Want("empty", [2]interface{}{&schema.Settings{}, nil}),
+			want: autogold.Want("empty", [2]any{&schema.Settings{}, nil}),
 		},
 		{
 			name:  "real",
 			input: settingsExample,
-			want: autogold.Want("real", [2]interface{}{
+			want: autogold.Want("real", [2]any{
 				&schema.Settings{Insights: []*schema.Insight{
 					{
 						Description: "errors.Errorf/fmt.Printf usage",
@@ -215,7 +215,7 @@ func Test_parseUserSettings(t *testing.T) {
 	for _, tst := range tests {
 		t.Run(tst.name, func(t *testing.T) {
 			got, err := parseUserSettings(tst.input)
-			tst.want.Equal(t, [2]interface{}{got, err})
+			tst.want.Equal(t, [2]any{got, err})
 		})
 	}
 

--- a/enterprise/internal/insights/discovery/mock_indexable_repos_lister.go
+++ b/enterprise/internal/insights/discovery/mock_indexable_repos_lister.go
@@ -139,12 +139,12 @@ type IndexableReposListerListFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c IndexableReposListerListFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c IndexableReposListerListFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c IndexableReposListerListFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c IndexableReposListerListFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }

--- a/enterprise/internal/insights/discovery/mock_repo_store.go
+++ b/enterprise/internal/insights/discovery/mock_repo_store.go
@@ -140,12 +140,12 @@ type RepoStoreListFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c RepoStoreListFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c RepoStoreListFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c RepoStoreListFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c RepoStoreListFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }

--- a/enterprise/internal/insights/discovery/mock_setting_store.go
+++ b/enterprise/internal/insights/discovery/mock_setting_store.go
@@ -157,14 +157,14 @@ type SettingStoreGetLastestSchemaSettingsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c SettingStoreGetLastestSchemaSettingsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c SettingStoreGetLastestSchemaSettingsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c SettingStoreGetLastestSchemaSettingsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c SettingStoreGetLastestSchemaSettingsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // SettingStoreGetLatestFunc describes the behavior when the GetLatest
@@ -266,12 +266,12 @@ type SettingStoreGetLatestFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c SettingStoreGetLatestFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c SettingStoreGetLatestFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c SettingStoreGetLatestFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c SettingStoreGetLatestFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }

--- a/enterprise/internal/insights/discovery/series_id_test.go
+++ b/enterprise/internal/insights/discovery/series_id_test.go
@@ -16,27 +16,27 @@ func TestEncodeSeriesID(t *testing.T) {
 	}{
 		{
 			input: &schema.InsightSeries{Search: "fmt.Errorf repo:github.com/golang/go"},
-			want: autogold.Want("basic_search", [2]interface{}{
+			want: autogold.Want("basic_search", [2]any{
 				"s:6CB26B840C8EEBFB03DDB44A23FFBD4D7AD864B47D9AA1E975E69FCF0EE2A67E",
 				"<nil>",
 			}),
 		},
 		{
 			input: &schema.InsightSeries{Webhook: "https://example.com/getData?foo=bar"},
-			want: autogold.Want("basic_webhook", [2]interface{}{
+			want: autogold.Want("basic_webhook", [2]any{
 				"w:CDAA477D902F8572B92EAC827A0E5FC27537BFC825EE358427E0DC04D22E0E25",
 				"<nil>",
 			}),
 		},
 		{
 			input: &schema.InsightSeries{},
-			want:  autogold.Want("invalid", [2]interface{}{"", "invalid series &{Label: RepositoriesList:[] Search: Webhook:}"}),
+			want:  autogold.Want("invalid", [2]any{"", "invalid series &{Label: RepositoriesList:[] Search: Webhook:}"}),
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.want.Name(), func(t *testing.T) {
 			got, err := EncodeSeriesID(tc.input)
-			tc.want.Equal(t, [2]interface{}{got, fmt.Sprint(err)})
+			tc.want.Equal(t, [2]any{got, fmt.Sprint(err)})
 		})
 	}
 }

--- a/enterprise/internal/insights/resolvers/insight_connection_resolver_test.go
+++ b/enterprise/internal/insights/resolvers/insight_connection_resolver_test.go
@@ -136,14 +136,14 @@ func TestResolver_InsightConnection(t *testing.T) {
 		if len(nodes) != 2 {
 			t.Fatal("incorrect length")
 		}
-		autogold.Want("first insight", map[string]interface{}{"description": "errors.Errorf/fmt.Printf usage", "title": "fmt usage"}).Equal(t, map[string]interface{}{
+		autogold.Want("first insight", map[string]any{"description": "errors.Errorf/fmt.Printf usage", "title": "fmt usage"}).Equal(t, map[string]any{
 			"title":       nodes[0].Title(),
 			"description": nodes[0].Description(),
 		})
 		// TODO(slimsag): put series length into map (autogold bug, omits the field for some reason?)
 		autogold.Want("first insight: series length", int(2)).Equal(t, len(nodes[0].Series()))
 
-		autogold.Want("second insight", map[string]interface{}{"description": "gitserver exec & close usage", "title": "gitserver usage"}).Equal(t, map[string]interface{}{
+		autogold.Want("second insight", map[string]any{"description": "gitserver exec & close usage", "title": "gitserver usage"}).Equal(t, map[string]any{
 			"title":       nodes[1].Title(),
 			"description": nodes[1].Description(),
 		})

--- a/enterprise/internal/insights/store/mock_store_dataseriesstore.go
+++ b/enterprise/internal/insights/store/mock_store_dataseriesstore.go
@@ -154,14 +154,14 @@ type DataSeriesStoreGetDataSeriesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DataSeriesStoreGetDataSeriesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DataSeriesStoreGetDataSeriesFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DataSeriesStoreGetDataSeriesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DataSeriesStoreGetDataSeriesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // DataSeriesStoreStampRecordingFunc describes the behavior when the
@@ -265,12 +265,12 @@ type DataSeriesStoreStampRecordingFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DataSeriesStoreStampRecordingFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c DataSeriesStoreStampRecordingFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DataSeriesStoreStampRecordingFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c DataSeriesStoreStampRecordingFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }

--- a/enterprise/internal/insights/store/mock_store_interface.go
+++ b/enterprise/internal/insights/store/mock_store_interface.go
@@ -159,14 +159,14 @@ type InterfaceCountDataFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c InterfaceCountDataFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c InterfaceCountDataFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c InterfaceCountDataFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c InterfaceCountDataFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // InterfaceRecordSeriesPointFunc describes the behavior when the
@@ -265,14 +265,14 @@ type InterfaceRecordSeriesPointFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c InterfaceRecordSeriesPointFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c InterfaceRecordSeriesPointFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c InterfaceRecordSeriesPointFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c InterfaceRecordSeriesPointFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // InterfaceSeriesPointsFunc describes the behavior when the SeriesPoints
@@ -374,12 +374,12 @@ type InterfaceSeriesPointsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c InterfaceSeriesPointsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c InterfaceSeriesPointsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c InterfaceSeriesPointsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c InterfaceSeriesPointsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }

--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -223,7 +223,7 @@ func seriesPointsQuery(opts SeriesPointsOpts) *sqlf.Query {
 	)
 }
 
-//values constructs a SQL values statement out of an array of repository ids
+// values constructs a SQL values statement out of an array of repository ids
 func values(ids []api.RepoID) string {
 	if len(ids) == 0 {
 		return ""
@@ -311,7 +311,7 @@ type RecordSeriesPointArgs struct {
 	//
 	// See the DB schema comments for intended use cases. This should generally be small,
 	// low-cardinality data to avoid inflating the table.
-	Metadata interface{}
+	Metadata any
 }
 
 // RecordSeriesPoint records a data point for the specfied series ID (which is a unique ID for the
@@ -423,7 +423,7 @@ func (s *Store) query(ctx context.Context, q *sqlf.Query, sc scanFunc) error {
 
 // scanner captures the Scan method of sql.Rows and sql.Row
 type scanner interface {
-	Scan(dst ...interface{}) error
+	Scan(dst ...any) error
 }
 
 // a scanFunc scans one or more rows from a scanner, returning

--- a/enterprise/internal/insights/store/store_test.go
+++ b/enterprise/internal/insights/store/store_test.go
@@ -160,17 +160,17 @@ func TestCountData(t *testing.T) {
 			Point:    SeriesPoint{Time: timeValue("2020-03-01T00:00:00Z"), Value: 1.1},
 			RepoName: optionalString("repo1"),
 			RepoID:   optionalRepoID(3),
-			Metadata: map[string]interface{}{"some": "data"},
+			Metadata: map[string]any{"some": "data"},
 		},
 		{
 			SeriesID: "two",
 			Point:    SeriesPoint{Time: timeValue("2020-03-02T00:00:00Z"), Value: 2.2},
-			Metadata: []interface{}{"some", "data", "two"},
+			Metadata: []any{"some", "data", "two"},
 		},
 		{
 			SeriesID: "two",
 			Point:    SeriesPoint{Time: timeValue("2020-03-02T00:01:00Z"), Value: 2.2},
-			Metadata: []interface{}{"some", "data", "two"},
+			Metadata: []any{"some", "data", "two"},
 		},
 		{
 			SeriesID: "three",
@@ -245,14 +245,14 @@ func TestRecordSeriesPoints(t *testing.T) {
 			Point:    SeriesPoint{Time: current, Value: 1.1},
 			RepoName: optionalString("repo1"),
 			RepoID:   optionalRepoID(3),
-			Metadata: map[string]interface{}{"some": "data"},
+			Metadata: map[string]any{"some": "data"},
 		},
 		{
 			SeriesID: "one",
 			Point:    SeriesPoint{Time: current.Add(-time.Hour * 24 * 15), Value: 2.2},
 			RepoName: optionalString("repo1"),
 			RepoID:   optionalRepoID(3),
-			Metadata: []interface{}{"some", "data", "two"},
+			Metadata: []any{"some", "data", "two"},
 		},
 		{
 			SeriesID: "one",

--- a/enterprise/internal/licensing/resolvers/resolvers_test.go
+++ b/enterprise/internal/licensing/resolvers/resolvers_test.go
@@ -80,7 +80,7 @@ func TestEnterpriseLicenseHasFeature(t *testing.T) {
 			}()
 
 			var have struct{ EnterpriseLicenseHasFeature bool }
-			if err := apitest.Exec(ctx, t, schema, map[string]interface{}{
+			if err := apitest.Exec(ctx, t, schema, map[string]any{
 				"feature": tc.feature,
 			}, &have, query); err != nil {
 				if !tc.wantErr {

--- a/internal/api/internal_client.go
+++ b/internal/api/internal_client.go
@@ -277,11 +277,11 @@ func (c *internalClient) PhabricatorRepoCreate(ctx context.Context, repo RepoNam
 	}, nil)
 }
 
-var MockExternalServiceConfigs func(kind string, result interface{}) error
+var MockExternalServiceConfigs func(kind string, result any) error
 
 // ExternalServiceConfigs fetches external service configs of a single kind into the result parameter,
 // which should be a slice of the expected config type.
-func (c *internalClient) ExternalServiceConfigs(ctx context.Context, kind string, result interface{}) error {
+func (c *internalClient) ExternalServiceConfigs(ctx context.Context, kind string, result any) error {
 	if MockExternalServiceConfigs != nil {
 		return MockExternalServiceConfigs(kind, result)
 	}
@@ -296,16 +296,16 @@ func (c *internalClient) ExternalServicesList(ctx context.Context, opts External
 	return extsvcs, c.postInternal(ctx, "external-services/list", &opts, &extsvcs)
 }
 
-func (c *internalClient) LogTelemetry(ctx context.Context, reqBody interface{}) error {
+func (c *internalClient) LogTelemetry(ctx context.Context, reqBody any) error {
 	return c.postInternal(ctx, "telemetry", reqBody, nil)
 }
 
 // postInternal sends an HTTP post request to the internal route.
-func (c *internalClient) postInternal(ctx context.Context, route string, reqBody, respBody interface{}) error {
+func (c *internalClient) postInternal(ctx context.Context, route string, reqBody, respBody any) error {
 	return c.meteredPost(ctx, "/.internal/"+route, reqBody, respBody)
 }
 
-func (c *internalClient) meteredPost(ctx context.Context, route string, reqBody, respBody interface{}) error {
+func (c *internalClient) meteredPost(ctx context.Context, route string, reqBody, respBody any) error {
 	start := time.Now()
 	statusCode, err := c.post(ctx, route, reqBody, respBody)
 	d := time.Since(start)
@@ -321,7 +321,7 @@ func (c *internalClient) meteredPost(ctx context.Context, route string, reqBody,
 // post sends an HTTP post request to the provided route. If reqBody is
 // non-nil it will Marshal it as JSON and set that as the Request body. If
 // respBody is non-nil the response body will be JSON unmarshalled to resp.
-func (c *internalClient) post(ctx context.Context, route string, reqBody, respBody interface{}) (int, error) {
+func (c *internalClient) post(ctx context.Context, route string, reqBody, respBody any) (int, error) {
 	var data []byte
 	if reqBody != nil {
 		var err error

--- a/internal/authz/bitbucketserver/provider_test.go
+++ b/internal/authz/bitbucketserver/provider_test.go
@@ -300,7 +300,7 @@ func testProviderFetchRepoPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 	}
 }
 
-func marshalJSON(v interface{}) []byte {
+func marshalJSON(v any) []byte {
 	bs, err := json.Marshal(v)
 	if err != nil {
 		panic(err)

--- a/internal/cmd/init-sg/main.go
+++ b/internal/cmd/init-sg/main.go
@@ -109,7 +109,7 @@ func initSourcegraph() {
 
 	log.Println("Instance initialized, SOURCEGRAPH_SUDO_TOKEN set in", profile)
 }
-func mustMarshalJSONString(v interface{}) string {
+func mustMarshalJSONString(v any) string {
 	str, err := jsoniter.MarshalToString(v)
 	if err != nil {
 		panic(err)

--- a/internal/cmd/precise-code-intel-tester/query.go
+++ b/internal/cmd/precise-code-intel-tester/query.go
@@ -164,7 +164,7 @@ func queryDefinitions(ctx context.Context, location Location) (locations []Locat
 		}
 	`
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"repository": location.Repo,
 		"commit":     location.Rev,
 		"path":       location.Path,
@@ -235,7 +235,7 @@ func queryReferences(ctx context.Context, location Location) (locations []Locati
 
 	endCursor := ""
 	for {
-		variables := map[string]interface{}{
+		variables := map[string]any{
 			"repository": location.Repo,
 			"commit":     location.Rev,
 			"path":       location.Path,

--- a/internal/cmd/precise-code-intel-tester/util/graphql.go
+++ b/internal/cmd/precise-code-intel-tester/util/graphql.go
@@ -26,8 +26,8 @@ type GraphQLError struct {
 // GraphQL query and helps e.g. a site admin know where such a query may be coming from. Importantly,
 // unnamed queries (empty string) are considered to be unknown end-user API requests and as such will
 // have the entire GraphQL request logged by the frontend, and cannot be uniquely identified in monitoring.
-func QueryGraphQL(ctx context.Context, endpoint, queryName string, token, query string, variables map[string]interface{}, target interface{}) error {
-	body, err := json.Marshal(map[string]interface{}{
+func QueryGraphQL(ctx context.Context, endpoint, queryName string, token, query string, variables map[string]any, target any) error {
+	body, err := json.Marshal(map[string]any{
 		"query":     query,
 		"variables": variables,
 	})

--- a/internal/cmd/resources-report/aws.go
+++ b/internal/cmd/resources-report/aws.go
@@ -54,7 +54,7 @@ var awsResources = map[string]AWSResourceFetchFunc{
 							Owner:      "-",
 							Type:       fmt.Sprintf("EC2::Instances::%s", string(instance.InstanceType)),
 							Created:    *instance.LaunchTime,
-							Meta: map[string]interface{}{
+							Meta: map[string]any{
 								"tags": ec2TagsToMap(instance.Tags),
 							},
 						}
@@ -78,7 +78,7 @@ var awsResources = map[string]AWSResourceFetchFunc{
 						Owner:      "-",
 						Type:       fmt.Sprintf("EC2::Volumes::%s", string(volume.VolumeType)),
 						Created:    *volume.CreateTime,
-						Meta: map[string]interface{}{
+						Meta: map[string]any{
 							"tags":        ec2TagsToMap(volume.Tags),
 							"attachments": volume.Attachments,
 						},
@@ -118,7 +118,7 @@ var awsResources = map[string]AWSResourceFetchFunc{
 						Owner:      "-",
 						Type:       "EKS::Cluster",
 						Created:    *cluster.Cluster.CreatedAt,
-						Meta: map[string]interface{}{
+						Meta: map[string]any{
 							"tags": cluster.Cluster.Tags, // tags are already a map
 						},
 					}

--- a/internal/cmd/resources-report/gcp.go
+++ b/internal/cmd/resources-report/gcp.go
@@ -59,7 +59,7 @@ var gcpResources = map[string]GCPResourceFetchFunc{
 									Owner:      project,
 									Type:       fmt.Sprintf("%s::%s", instance.Kind, machineType),
 									Created:    created,
-									Meta: map[string]interface{}{
+									Meta: map[string]any{
 										"labels": instance.Labels,
 									},
 								}
@@ -87,7 +87,7 @@ var gcpResources = map[string]GCPResourceFetchFunc{
 									Owner:      project,
 									Type:       fmt.Sprintf("%s::%s::%dGB", disk.Kind, diskType, disk.SizeGb),
 									Created:    created,
-									Meta: map[string]interface{}{
+									Meta: map[string]any{
 										"labels": disk.Labels,
 									},
 								}
@@ -131,7 +131,7 @@ var gcpResources = map[string]GCPResourceFetchFunc{
 					Owner:      project,
 					Location:   cluster.Zone,
 					Created:    created,
-					Meta: map[string]interface{}{
+					Meta: map[string]any{
 						"labels": cluster.ResourceLabels,
 					},
 				}

--- a/internal/cmd/resources-report/resource.go
+++ b/internal/cmd/resources-report/resource.go
@@ -23,7 +23,7 @@ type Resource struct {
 	Location   string
 	Owner      string
 	Created    time.Time
-	Meta       map[string]interface{}
+	Meta       map[string]any
 
 	Allowed bool
 }

--- a/internal/cmd/resources-report/sheets.go
+++ b/internal/cmd/resources-report/sheets.go
@@ -14,10 +14,10 @@ import (
 	"google.golang.org/api/sheets/v4"
 )
 
-var reportSheetHeaders = []interface{}{"Platform", "Type", "ID", "Location", "Owner", "Created", "Meta"}
+var reportSheetHeaders = []any{"Platform", "Type", "ID", "Location", "Owner", "Created", "Meta"}
 
-func toSheetValues(resources Resources) [][]interface{} {
-	values := make([][]interface{}, len(resources)+1)
+func toSheetValues(resources Resources) [][]any {
+	values := make([][]any, len(resources)+1)
 	values[0] = reportSheetHeaders
 	for i, resource := range resources {
 		var meta string
@@ -25,7 +25,7 @@ func toSheetValues(resources Resources) [][]interface{} {
 		if err == nil {
 			meta = string(metaBytes)
 		}
-		values[i+1] = []interface{}{
+		values[i+1] = []any{
 			resource.Platform,
 			resource.Type,
 			resource.Identifier,

--- a/internal/cmd/resources-report/slack.go
+++ b/internal/cmd/resources-report/slack.go
@@ -17,7 +17,7 @@ type slackMessage struct {
 	Blocks []slackBlock `json:"blocks"`
 }
 
-type slackBlock map[string]interface{}
+type slackBlock map[string]any
 
 const slackTextMarkdown = "mrkdwn"
 

--- a/internal/cmd/search-blitz/client.go
+++ b/internal/cmd/search-blitz/client.go
@@ -43,7 +43,7 @@ func newClient() (*client, error) {
 
 func (s *client) search(ctx context.Context, query, queryName string) (*metrics, error) {
 	var body bytes.Buffer
-	if err := json.NewEncoder(&body).Encode(map[string]interface{}{
+	if err := json.NewEncoder(&body).Encode(map[string]any{
 		"query":     graphQLQuery,
 		"variables": map[string]string{"query": query},
 	}); err != nil {

--- a/internal/cmd/search-blitz/config.go
+++ b/internal/cmd/search-blitz/config.go
@@ -42,7 +42,7 @@ const (
 	Stream
 )
 
-func (s *Protocol) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (s *Protocol) UnmarshalYAML(unmarshal func(any) error) error {
 	var v string
 	if err := unmarshal(&v); err != nil {
 		return err

--- a/internal/cmd/search-blitz/main.go
+++ b/internal/cmd/search-blitz/main.go
@@ -155,7 +155,7 @@ type tsvLogger struct {
 	buf bytes.Buffer
 }
 
-func (t *tsvLogger) Log(a ...interface{}) {
+func (t *tsvLogger) Log(a ...any) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 

--- a/internal/cmd/search-blitz/protocol.go
+++ b/internal/cmd/search-blitz/protocol.go
@@ -3,8 +3,8 @@ package main
 import "time"
 
 type rawResult struct {
-	Data   result        `json:"data,omitempty"`
-	Errors []interface{} `json:"errors,omitempty"`
+	Data   result `json:"data,omitempty"`
+	Errors []any  `json:"errors,omitempty"`
 }
 
 type result struct {
@@ -18,9 +18,9 @@ type result struct {
 
 // searchResults represents the data we get back from the GraphQL search request.
 type searchResults struct {
-	Results                    []map[string]interface{}
+	Results                    []map[string]any
 	LimitHit                   bool
-	Cloning, Missing, Timedout []map[string]interface{}
+	Cloning, Missing, Timedout []map[string]any
 	ResultCount                int
 	ElapsedMilliseconds        int
 	Alert                      searchResultsAlert

--- a/internal/cmd/tracking-issue/issue_loader.go
+++ b/internal/cmd/tracking-issue/issue_loader.go
@@ -143,7 +143,7 @@ func (l *IssueLoader) Load(ctx context.Context, cli *graphql.Client) (issues []*
 func (l *IssueLoader) makeNextRequest() (*graphql.Request, bool) {
 	var args []string
 	var fragments []string
-	vars := map[string]interface{}{}
+	vars := map[string]any{}
 
 	cost := 0
 	for i := range l.queries {

--- a/internal/conf/client.go
+++ b/internal/conf/client.go
@@ -109,7 +109,7 @@ func Watch(f func()) {
 // will be recomputed every time the config is updated.
 //
 // IMPORTANT: The first call to wrapped will block on config initialization.
-func Cached(f func() interface{}) (wrapped func() interface{}) {
+func Cached(f func() any) (wrapped func() any) {
 	return defaultClient().Cached(f)
 }
 
@@ -143,10 +143,10 @@ func (c *client) Watch(f func()) {
 // will be recomputed every time the config is updated.
 //
 // The first call to wrapped will block on config initialization.
-func (c *client) Cached(f func() interface{}) (wrapped func() interface{}) {
+func (c *client) Cached(f func() any) (wrapped func() any) {
 	var once sync.Once
 	var val atomic.Value
-	return func() interface{} {
+	return func() any {
 		once.Do(func() {
 			c.Watch(func() {
 				val.Store(f())
@@ -181,8 +181,8 @@ type continuousUpdateOptions struct {
 	// contact the frontend for configuration) start up before the frontend.
 	delayBeforeUnreachableLog time.Duration
 
-	log   func(format string, v ...interface{}) // log.Printf equivalent
-	sleep func()                                // sleep between updates
+	log   func(format string, v ...any) // log.Printf equivalent
+	sleep func()                        // sleep between updates
 }
 
 // continuouslyUpdate runs (*client).fetchAndUpdate in an infinite loop, with error logging and

--- a/internal/conf/client_test.go
+++ b/internal/conf/client_test.go
@@ -36,7 +36,7 @@ func TestClient_continuouslyUpdate(t *testing.T) {
 		const delayBeforeUnreachableLog = 150 * time.Millisecond // assumes first loop iter executes within this time period
 		go client.continuouslyUpdate(&continuousUpdateOptions{
 			delayBeforeUnreachableLog: delayBeforeUnreachableLog,
-			log: func(format string, v ...interface{}) {
+			log: func(format string, v ...any) {
 				logMessages = append(logMessages, fmt.Sprintf(format, v...))
 			},
 			sleep: func() {

--- a/internal/conf/computed_test.go
+++ b/internal/conf/computed_test.go
@@ -17,7 +17,7 @@ func TestSearchIndexEnabled(t *testing.T) {
 		name string
 		sc   *Unified
 		env  []string
-		want interface{}
+		want any
 	}{{
 		name: "SearchIndex defaults to false in docker",
 		sc:   &Unified{},

--- a/internal/conf/diff.go
+++ b/internal/conf/diff.go
@@ -18,7 +18,7 @@ func diff(before, after *Unified) (fields map[string]struct{}) {
 	return diff
 }
 
-func diffStruct(before, after interface{}, prefix string) (fields map[string]struct{}) {
+func diffStruct(before, after any, prefix string) (fields map[string]struct{}) {
 	fields = make(map[string]struct{})
 	beforeFields := getJSONFields(before, prefix)
 	afterFields := getJSONFields(after, prefix)
@@ -31,8 +31,8 @@ func diffStruct(before, after interface{}, prefix string) (fields map[string]str
 	return fields
 }
 
-func getJSONFields(vv interface{}, prefix string) (fields map[string]interface{}) {
-	fields = make(map[string]interface{})
+func getJSONFields(vv any, prefix string) (fields map[string]any) {
+	fields = make(map[string]any)
 	v := reflect.ValueOf(vv)
 	for i := 0; i < v.NumField(); i++ {
 		f := v.Field(i)

--- a/internal/conf/parse.go
+++ b/internal/conf/parse.go
@@ -10,7 +10,7 @@ import (
 
 // parseConfigData parses the provided config string into the given cfg struct
 // pointer.
-func parseConfigData(data string, cfg interface{}) error {
+func parseConfigData(data string, cfg any) error {
 	if data != "" {
 		data, err := jsonc.Parse(data)
 		if err != nil {

--- a/internal/conf/reposource/custom.go
+++ b/internal/conf/reposource/custom.go
@@ -29,7 +29,7 @@ type cloneURLResolver struct {
 
 // cloneURLResolvers is the list of clone-URL-to-repo-URI mappings, derived
 // from the site config
-var cloneURLResolvers = conf.Cached(func() interface{} {
+var cloneURLResolvers = conf.Cached(func() any {
 	cloneURLConfig := conf.Get().GitCloneURLToRepositoryName
 	var resolvers []*cloneURLResolver
 	for _, c := range cloneURLConfig {

--- a/internal/conf/reposource/custom_test.go
+++ b/internal/conf/reposource/custom_test.go
@@ -46,7 +46,7 @@ func TestCustomCloneURLToRepoName(t *testing.T) {
 	}}
 
 	for i, test := range tests {
-		cloneURLResolvers = func() interface{} { return test.cloneURLResolvers }
+		cloneURLResolvers = func() any { return test.cloneURLResolvers }
 		for cloneURL, expName := range test.cloneURLToRepoName {
 			if name := CustomCloneURLToRepoName(cloneURL); name != expName {
 				t.Errorf("In test case %d, expected %s -> %s, but got %s", i+1, cloneURL, expName, name)

--- a/internal/conf/validate_custom.go
+++ b/internal/conf/validate_custom.go
@@ -80,7 +80,7 @@ func validateCustom(cfg Unified) (problems Problems) {
 // TestValidator is an exported helper function for other packages to test their contributed
 // validators (registered with ContributeValidator). It should only be called by tests.
 func TestValidator(t interface {
-	Errorf(format string, args ...interface{})
+	Errorf(format string, args ...any)
 	Helper()
 }, c Unified, f Validator, wantProblems Problems) {
 	t.Helper()

--- a/internal/database/authenticator.go
+++ b/internal/database/authenticator.go
@@ -34,7 +34,7 @@ const (
 type NullAuthenticator struct{ A *auth.Authenticator }
 
 // Scan implements the Scanner interface.
-func (n *NullAuthenticator) Scan(value interface{}) (err error) {
+func (n *NullAuthenticator) Scan(value any) (err error) {
 	switch value := value.(type) {
 	case string:
 		*n.A, err = UnmarshalAuthenticator(value)
@@ -122,7 +122,7 @@ func UnmarshalAuthenticator(raw string) (auth.Authenticator, error) {
 		return nil, err
 	}
 
-	var a interface{}
+	var a any
 	switch partial.Type {
 	case AuthenticatorTypeOAuthClient:
 		a = &auth.OAuthClient{}

--- a/internal/database/batch/batch_test.go
+++ b/internal/database/batch/batch_test.go
@@ -31,7 +31,7 @@ func TestBatchInserter(t *testing.T) {
 	}
 	defer rows.Close()
 
-	var values [][]interface{}
+	var values [][]any
 	for rows.Next() {
 		var v1, v2, v3, v4 int
 		var v5 string
@@ -39,7 +39,7 @@ func TestBatchInserter(t *testing.T) {
 			t.Fatalf("unexpected error scanning data: %s", err)
 		}
 
-		values = append(values, []interface{}{v1, v2, v3, v4, v5})
+		values = append(values, []any{v1, v2, v3, v4, v5})
 	}
 
 	if diff := cmp.Diff(expectedValues, values); diff != "" {
@@ -114,10 +114,10 @@ func setupTestTable(t testing.TB, db *sql.DB) {
 	})
 }
 
-func makeTestValues(tableSizeFactor, payloadSize int) [][]interface{} {
-	var expectedValues [][]interface{}
+func makeTestValues(tableSizeFactor, payloadSize int) [][]any {
+	var expectedValues [][]any
 	for i := 0; i < maxNumParameters*tableSizeFactor; i++ {
-		expectedValues = append(expectedValues, []interface{}{
+		expectedValues = append(expectedValues, []any{
 			i,
 			i + 1,
 			i + 2,
@@ -138,7 +138,7 @@ func makePayload(size int) string {
 	return string(s)
 }
 
-func testInsert(t testing.TB, db *sql.DB, expectedValues [][]interface{}) {
+func testInsert(t testing.TB, db *sql.DB, expectedValues [][]any) {
 	ctx := context.Background()
 
 	inserter := NewInserter(ctx, db, "batch_inserter_test", "col1", "col2", "col3", "col4", "col5")
@@ -153,7 +153,7 @@ func testInsert(t testing.TB, db *sql.DB, expectedValues [][]interface{}) {
 	}
 }
 
-func testInsertWithReturn(t testing.TB, db *sql.DB, expectedValues [][]interface{}) (insertedIDs []int) {
+func testInsertWithReturn(t testing.TB, db *sql.DB, expectedValues [][]any) (insertedIDs []int) {
 	ctx := context.Background()
 
 	inserter := NewInserterWithReturn(

--- a/internal/database/dbconn/dbconn.go
+++ b/internal/database/dbconn/dbconn.go
@@ -326,7 +326,7 @@ var postgresBulkInsertRowsPattern = lazyregexp.New(`(\([$\d,\s]+\)[,\s]*)+`)
 var postgresBulkInsertRowsReplacement = []byte("(...) ")
 
 // Before implements sqlhooks.Hooks
-func (h *hook) Before(ctx context.Context, query string, args ...interface{}) (context.Context, error) {
+func (h *hook) Before(ctx context.Context, query string, args ...any) (context.Context, error) {
 	if BulkInsertion(ctx) {
 		query = string(postgresBulkInsertRowsPattern.ReplaceAll([]byte(query), postgresBulkInsertRowsReplacement))
 	}
@@ -361,7 +361,7 @@ func (h *hook) Before(ctx context.Context, query string, args ...interface{}) (c
 }
 
 // After implements sqlhooks.Hooks
-func (h *hook) After(ctx context.Context, query string, args ...interface{}) (context.Context, error) {
+func (h *hook) After(ctx context.Context, query string, args ...any) (context.Context, error) {
 	if tr := trace.TraceFromContext(ctx); tr != nil {
 		tr.Finish()
 	}
@@ -369,7 +369,7 @@ func (h *hook) After(ctx context.Context, query string, args ...interface{}) (co
 }
 
 // OnError implements sqlhooks.OnError
-func (h *hook) OnError(ctx context.Context, err error, query string, args ...interface{}) error {
+func (h *hook) OnError(ctx context.Context, err error, query string, args ...any) error {
 	if tr := trace.TraceFromContext(ctx); tr != nil {
 		tr.SetError(err)
 		tr.Finish()

--- a/internal/database/dbconn/migration.go
+++ b/internal/database/dbconn/migration.go
@@ -119,7 +119,7 @@ func DoMigrate(m *migrate.Migrate) (err error) {
 
 type stdoutLogger struct{}
 
-func (stdoutLogger) Printf(format string, v ...interface{}) {
+func (stdoutLogger) Printf(format string, v ...any) {
 	fmt.Printf(format, v...)
 }
 func (logger stdoutLogger) Verbose() bool {

--- a/internal/database/dbtest/dbtest.go
+++ b/internal/database/dbtest/dbtest.go
@@ -20,7 +20,9 @@ import (
 // transaction if an error didn't occur.
 //
 // After opening this transaction, it executes the query
-//     SET CONSTRAINTS ALL DEFERRED
+//
+//	SET CONSTRAINTS ALL DEFERRED
+//
 // which aids in testing.
 func NewTx(t testing.TB, db *sql.DB) *sql.Tx {
 	tx, err := db.Begin()
@@ -169,7 +171,7 @@ func dbConn(t testing.TB, cfg *url.URL) *sql.DB {
 	return db
 }
 
-func dbExec(t testing.TB, db *sql.DB, q string, args ...interface{}) {
+func dbExec(t testing.TB, db *sql.DB, q string, args ...any) {
 	t.Helper()
 	_, err := db.Exec(q, args...)
 	if err != nil {

--- a/internal/database/dbtesting/dbtesting.go
+++ b/internal/database/dbtesting/dbtesting.go
@@ -181,14 +181,14 @@ func initTest(nameSuffix string) error {
 // in tests that require the database handle but never call it.
 type MockDB struct{}
 
-func (db *MockDB) QueryContext(ctx context.Context, q string, args ...interface{}) (*sql.Rows, error) {
+func (db *MockDB) QueryContext(ctx context.Context, q string, args ...any) (*sql.Rows, error) {
 	panic("mock db methods are not supposed to be called")
 }
 
-func (db *MockDB) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+func (db *MockDB) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
 	panic("mock db methods are not supposed to be called")
 }
 
-func (db *MockDB) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+func (db *MockDB) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
 	panic("mock db methods are not supposed to be called")
 }

--- a/internal/database/dbutil/dbutil.go
+++ b/internal/database/dbutil/dbutil.go
@@ -51,9 +51,9 @@ func Transaction(ctx context.Context, db *sql.DB, f func(tx *sql.Tx) error) (err
 
 // A DB captures the essential method of a sql.DB: QueryContext.
 type DB interface {
-	QueryContext(ctx context.Context, q string, args ...interface{}) (*sql.Rows, error)
-	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
-	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
+	QueryContext(ctx context.Context, q string, args ...any) (*sql.Rows, error)
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 }
 
 // A Tx captures the essential methods of a sql.Tx.
@@ -78,7 +78,7 @@ func IsPostgresError(err error, codename string) bool {
 type NullTime struct{ *time.Time }
 
 // Scan implements the Scanner interface.
-func (nt *NullTime) Scan(value interface{}) error {
+func (nt *NullTime) Scan(value any) error {
 	*nt.Time, _ = value.(time.Time)
 	return nil
 }
@@ -105,7 +105,7 @@ func NewNullString(s string) NullString {
 }
 
 // Scan implements the Scanner interface.
-func (nt *NullString) Scan(value interface{}) error {
+func (nt *NullString) Scan(value any) error {
 	switch v := value.(type) {
 	case []byte:
 		*nt.S = string(v)
@@ -129,7 +129,7 @@ func (nt NullString) Value() (driver.Value, error) {
 type NullInt32 struct{ N *int32 }
 
 // Scan implements the Scanner interface.
-func (n *NullInt32) Scan(value interface{}) error {
+func (n *NullInt32) Scan(value any) error {
 	switch value := value.(type) {
 	case int64:
 		*n.N = int32(value)
@@ -165,7 +165,7 @@ func NewNullInt64(i int64) NullInt64 {
 }
 
 // Scan implements the Scanner interface.
-func (n *NullInt64) Scan(value interface{}) error {
+func (n *NullInt64) Scan(value any) error {
 	switch value := value.(type) {
 	case int64:
 		*n.N = value
@@ -201,7 +201,7 @@ func NewNullInt(i int) NullInt {
 }
 
 // Scan implements the Scanner interface.
-func (n *NullInt) Scan(value interface{}) error {
+func (n *NullInt) Scan(value any) error {
 	switch value := value.(type) {
 	case int64:
 		*n.N = int(value)
@@ -230,7 +230,7 @@ func (n NullInt) Value() (driver.Value, error) {
 type JSONInt64Set struct{ Set *[]int64 }
 
 // Scan implements the Scanner interface.
-func (n *JSONInt64Set) Scan(value interface{}) error {
+func (n *JSONInt64Set) Scan(value any) error {
 	set := make(map[int64]*struct{})
 
 	switch value := value.(type) {
@@ -272,7 +272,7 @@ type NullJSONRawMessage struct {
 }
 
 // Scan implements the Scanner interface.
-func (n *NullJSONRawMessage) Scan(value interface{}) error {
+func (n *NullJSONRawMessage) Scan(value any) error {
 	switch value := value.(type) {
 	case nil:
 	case []byte:
@@ -297,7 +297,7 @@ func (n *NullJSONRawMessage) Value() (driver.Value, error) {
 type CommitBytea string
 
 // Scan implements the Scanner interface.
-func (c *CommitBytea) Scan(value interface{}) error {
+func (c *CommitBytea) Scan(value any) error {
 	switch value := value.(type) {
 	case nil:
 	case []byte:
@@ -373,7 +373,7 @@ func PostgresDSN(prefix, currentUser string, getenv func(string) string) string 
 
 // Scanner captures the Scan method of sql.Rows and sql.Row
 type Scanner interface {
-	Scan(dst ...interface{}) error
+	Scan(dst ...any) error
 }
 
 // A ScanFunc scans one or more rows from a scanner, returning

--- a/internal/database/err_test.go
+++ b/internal/database/err_test.go
@@ -23,6 +23,6 @@ func TestErrorsInterface(t *testing.T) {
 	}
 }
 
-func functionName(i interface{}) string {
+func functionName(i any) string {
 	return runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
 }

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -23,7 +23,7 @@ import (
 
 // userExternalAccountNotFoundError is the error that is returned when a user external account is not found.
 type userExternalAccountNotFoundError struct {
-	args []interface{}
+	args []any
 }
 
 func (err userExternalAccountNotFoundError) Error() string {
@@ -142,7 +142,7 @@ AND deleted_at IS NULL
 RETURNING user_id
 `, spec.ServiceType, spec.ServiceID, spec.ClientID, spec.AccountID, data.AuthData, data.Data, keyID).Scan(&userID)
 	if err == sql.ErrNoRows {
-		err = userExternalAccountNotFoundError{[]interface{}{spec}}
+		err = userExternalAccountNotFoundError{[]any{spec}}
 	}
 	return userID, err
 }
@@ -243,7 +243,7 @@ AND deleted_at IS NULL
 		return err
 	}
 	if nrows == 0 {
-		return userExternalAccountNotFoundError{[]interface{}{existingID}}
+		return userExternalAccountNotFoundError{[]any{existingID}}
 	}
 	return nil
 }
@@ -354,7 +354,7 @@ func (s *UserExternalAccountsStore) Delete(ctx context.Context, id int32) error 
 		return err
 	}
 	if nrows == 0 {
-		return userExternalAccountNotFoundError{[]interface{}{id}}
+		return userExternalAccountNotFoundError{[]any{id}}
 	}
 	return nil
 }

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -421,7 +421,7 @@ func (e *ExternalServiceStore) validatePerforceConnection(ctx context.Context, i
 
 // validateDuplicateRateLimits returns an error if given config has duplicated non-default rate limit
 // with another external service for the same code host.
-func (e *ExternalServiceStore) validateDuplicateRateLimits(ctx context.Context, id int64, kind string, parsedConfig interface{}) error {
+func (e *ExternalServiceStore) validateDuplicateRateLimits(ctx context.Context, id int64, kind string, parsedConfig any) error {
 	// Check if rate limit is already defined for this code host on another external service
 	rlc, err := extsvc.GetLimitFromConfig(kind, parsedConfig)
 	if err != nil {
@@ -1132,8 +1132,8 @@ ORDER BY es.id, essj.finished_at DESC
 // If no namespace is given, it returns all external services.
 //
 // 🚨 SECURITY: The caller must ensure one of the following:
-// 	- The actor is a site admin
-// 	- The opt.NamespaceUserID is same as authenticated user ID (i.e. actor.UID)
+//   - The actor is a site admin
+//   - The opt.NamespaceUserID is same as authenticated user ID (i.e. actor.UID)
 func (e *ExternalServiceStore) List(ctx context.Context, opt ExternalServicesListOptions) ([]*types.ExternalService, error) {
 	if Mocks.ExternalServices.List != nil {
 		return Mocks.ExternalServices.List(opt)

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -35,7 +35,7 @@ func TestExternalServicesListOptions_sqlConditions(t *testing.T) {
 		afterID          int64
 		wantQuery        string
 		onlyCloudDefault bool
-		wantArgs         []interface{}
+		wantArgs         []any
 	}{
 		{
 			name:      "no condition",
@@ -45,19 +45,19 @@ func TestExternalServicesListOptions_sqlConditions(t *testing.T) {
 			name:      "only one kind: GitHub",
 			kinds:     []string{extsvc.KindGitHub},
 			wantQuery: "deleted_at IS NULL AND kind IN ($1)",
-			wantArgs:  []interface{}{extsvc.KindGitHub},
+			wantArgs:  []any{extsvc.KindGitHub},
 		},
 		{
 			name:      "two kinds: GitHub and GitLab",
 			kinds:     []string{extsvc.KindGitHub, extsvc.KindGitLab},
 			wantQuery: "deleted_at IS NULL AND kind IN ($1 , $2)",
-			wantArgs:  []interface{}{extsvc.KindGitHub, extsvc.KindGitLab},
+			wantArgs:  []any{extsvc.KindGitHub, extsvc.KindGitLab},
 		},
 		{
 			name:            "has namespace user ID",
 			namespaceUserID: 1,
 			wantQuery:       "deleted_at IS NULL AND namespace_user_id = $1",
-			wantArgs:        []interface{}{int32(1)},
+			wantArgs:        []any{int32(1)},
 		},
 		{
 			name:            "want no namespace",
@@ -69,7 +69,7 @@ func TestExternalServicesListOptions_sqlConditions(t *testing.T) {
 			name:      "has after ID",
 			afterID:   10,
 			wantQuery: "deleted_at IS NULL AND id < $1",
-			wantArgs:  []interface{}{int64(10)},
+			wantArgs:  []any{int64(10)},
 		},
 		{
 			name:             "has OnlyCloudDefault",

--- a/internal/database/feature_flags.go
+++ b/internal/database/feature_flags.go
@@ -159,7 +159,7 @@ var ErrInvalidColumnState = errors.New("encountered column that is unexpectedly 
 
 // rowScanner is an interface that can scan from either a sql.Row or sql.Rows
 type rowScanner interface {
-	Scan(...interface{}) error
+	Scan(...any) error
 }
 
 func scanFeatureFlag(scanner rowScanner) (*ff.FeatureFlag, error) {

--- a/internal/database/feature_flags_test.go
+++ b/internal/database/feature_flags_test.go
@@ -30,7 +30,7 @@ func TestFeatureFlagStore(t *testing.T) {
 }
 
 func errorContains(s string) require.ErrorAssertionFunc {
-	return func(t require.TestingT, err error, msg ...interface{}) {
+	return func(t require.TestingT, err error, msg ...any) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), s, msg)
 	}

--- a/internal/database/org_invitations.go
+++ b/internal/database/org_invitations.go
@@ -58,7 +58,7 @@ func (s *OrgInvitationStore) Transact(ctx context.Context) (*OrgInvitationStore,
 
 // OrgInvitationNotFoundError occurs when an org invitation is not found.
 type OrgInvitationNotFoundError struct {
-	args []interface{}
+	args []any
 }
 
 // NotFound implements errcode.NotFounder.
@@ -105,7 +105,7 @@ func (s *OrgInvitationStore) GetByID(ctx context.Context, id int64) (*OrgInvitat
 		return nil, err
 	}
 	if len(results) == 0 {
-		return nil, OrgInvitationNotFoundError{[]interface{}{id}}
+		return nil, OrgInvitationNotFoundError{[]any{id}}
 	}
 	return results[0], nil
 }
@@ -122,7 +122,7 @@ func (s *OrgInvitationStore) GetPending(ctx context.Context, orgID, recipientUse
 		return nil, err
 	}
 	if len(results) == 0 {
-		return nil, OrgInvitationNotFoundError{[]interface{}{fmt.Sprintf("pending for org %d recipient %d", orgID, recipientUserID)}}
+		return nil, OrgInvitationNotFoundError{[]any{fmt.Sprintf("pending for org %d recipient %d", orgID, recipientUserID)}}
 	}
 	return results[0], nil
 }
@@ -207,7 +207,7 @@ func (s *OrgInvitationStore) UpdateEmailSentTimestamp(ctx context.Context, id in
 		return err
 	}
 	if nrows == 0 {
-		return OrgInvitationNotFoundError{[]interface{}{id}}
+		return OrgInvitationNotFoundError{[]any{id}}
 	}
 	return nil
 }
@@ -217,7 +217,7 @@ func (s *OrgInvitationStore) UpdateEmailSentTimestamp(ctx context.Context, id in
 // OrgInvitationNotFoundError error is returned.
 func (s *OrgInvitationStore) Respond(ctx context.Context, id int64, recipientUserID int32, accept bool) (orgID int32, err error) {
 	if err := s.Handle().DB().QueryRowContext(ctx, "UPDATE org_invitations SET responded_at=now(), response_type=$3 WHERE id=$1 AND recipient_user_id=$2 AND responded_at IS NULL AND revoked_at IS NULL AND deleted_at IS NULL RETURNING org_id", id, recipientUserID, accept).Scan(&orgID); err == sql.ErrNoRows {
-		return 0, OrgInvitationNotFoundError{[]interface{}{fmt.Sprintf("id %d recipient %d", id, recipientUserID)}}
+		return 0, OrgInvitationNotFoundError{[]any{fmt.Sprintf("id %d recipient %d", id, recipientUserID)}}
 	} else if err != nil {
 		return 0, err
 	}
@@ -240,7 +240,7 @@ func (s *OrgInvitationStore) Revoke(ctx context.Context, id int64) error {
 		return err
 	}
 	if nrows == 0 {
-		return OrgInvitationNotFoundError{[]interface{}{id}}
+		return OrgInvitationNotFoundError{[]any{id}}
 	}
 	return nil
 }

--- a/internal/database/org_members.go
+++ b/internal/database/org_members.go
@@ -84,7 +84,7 @@ func (m *OrgMemberStore) GetByOrgID(ctx context.Context, orgID int32) ([]*types.
 // ErrOrgMemberNotFound is the error that is returned when
 // a user is not in an org.
 type ErrOrgMemberNotFound struct {
-	args []interface{}
+	args []any
 }
 
 func (err *ErrOrgMemberNotFound) Error() string {
@@ -93,7 +93,7 @@ func (err *ErrOrgMemberNotFound) Error() string {
 
 func (ErrOrgMemberNotFound) NotFound() bool { return true }
 
-func (m *OrgMemberStore) getOneBySQL(ctx context.Context, query string, args ...interface{}) (*types.OrgMembership, error) {
+func (m *OrgMemberStore) getOneBySQL(ctx context.Context, query string, args ...any) (*types.OrgMembership, error) {
 	members, err := m.getBySQL(ctx, query, args...)
 	if err != nil {
 		return nil, err
@@ -104,7 +104,7 @@ func (m *OrgMemberStore) getOneBySQL(ctx context.Context, query string, args ...
 	return members[0], nil
 }
 
-func (m *OrgMemberStore) getBySQL(ctx context.Context, query string, args ...interface{}) ([]*types.OrgMembership, error) {
+func (m *OrgMemberStore) getBySQL(ctx context.Context, query string, args ...any) ([]*types.OrgMembership, error) {
 	rows, err := m.Handle().DB().QueryContext(ctx, "SELECT org_members.id, org_members.org_id, org_members.user_id, org_members.created_at, org_members.updated_at FROM org_members "+query, args...)
 	if err != nil {
 		return nil, err

--- a/internal/database/orgs.go
+++ b/internal/database/orgs.go
@@ -150,7 +150,7 @@ func (*OrgStore) listSQL(opt OrgsListOptions) *sqlf.Query {
 	return sqlf.Sprintf("(%s)", sqlf.Join(conds, ") AND ("))
 }
 
-func (o *OrgStore) getBySQL(ctx context.Context, query string, args ...interface{}) ([]*types.Org, error) {
+func (o *OrgStore) getBySQL(ctx context.Context, query string, args ...any) ([]*types.Org, error) {
 	rows, err := o.Handle().DB().QueryContext(ctx, "SELECT id, name, display_name, created_at, updated_at FROM orgs "+query, args...)
 	if err != nil {
 		return nil, err

--- a/internal/database/phabricator.go
+++ b/internal/database/phabricator.go
@@ -40,7 +40,7 @@ func (s *PhabricatorStore) Transact(ctx context.Context) (*PhabricatorStore, err
 }
 
 type errPhabricatorRepoNotFound struct {
-	args []interface{}
+	args []any
 }
 
 func (err errPhabricatorRepoNotFound) Error() string {
@@ -95,7 +95,7 @@ func (p *PhabricatorStore) CreateIfNotExists(ctx context.Context, callsign strin
 	return repo, nil
 }
 
-func (p *PhabricatorStore) getBySQL(ctx context.Context, query string, args ...interface{}) ([]*types.PhabricatorRepo, error) {
+func (p *PhabricatorStore) getBySQL(ctx context.Context, query string, args ...any) ([]*types.PhabricatorRepo, error) {
 	rows, err := p.Handle().DB().QueryContext(ctx, "SELECT id, callsign, repo_name, url FROM phabricator_repos "+query, args...)
 	if err != nil {
 		return nil, err
@@ -117,7 +117,7 @@ func (p *PhabricatorStore) getBySQL(ctx context.Context, query string, args ...i
 	return repos, nil
 }
 
-func (p *PhabricatorStore) getOneBySQL(ctx context.Context, query string, args ...interface{}) (*types.PhabricatorRepo, error) {
+func (p *PhabricatorStore) getOneBySQL(ctx context.Context, query string, args ...any) (*types.PhabricatorRepo, error) {
 	rows, err := p.getBySQL(ctx, query, args...)
 	if err != nil {
 		return nil, err

--- a/internal/database/query/query.go
+++ b/internal/database/query/query.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Q is a query item. It is converted into a *sqlf.Query by Eval.
-type Q interface{}
+type Q any
 
 // And returns a Q which when evaluated will join the children by "AND".
 func And(children ...Q) Q {
@@ -48,12 +48,12 @@ type not struct {
 //
 // For example in the expression
 //
-//   And("atom1", Or(true, "atom2", &atom3{})
+//	And("atom1", Or(true, "atom2", &atom3{})
 //
 // atomToQueryFn is responsible for converting "atom1", "atom2" and &atom3{}
 // into sqlf.Query patterns. Eval will return the expression:
 //
-//   (query1 AND (query2 OR query3))
+//	(query1 AND (query2 OR query3))
 //
 // Where queryN is the respective output of atomToQueryFn.
 //

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -1140,7 +1140,7 @@ func nullStringColumn(s string) *string {
 	return &s
 }
 
-func metadataColumn(metadata interface{}) (msg json.RawMessage, err error) {
+func metadataColumn(metadata any) (msg json.RawMessage, err error) {
 	switch m := metadata.(type) {
 	case nil:
 		msg = json.RawMessage("{}")

--- a/internal/database/survey_responses.go
+++ b/internal/database/survey_responses.go
@@ -50,7 +50,7 @@ func (s *SurveyResponseStore) Create(ctx context.Context, userID *int32, email *
 	return id, err
 }
 
-func (s *SurveyResponseStore) getBySQL(ctx context.Context, query string, args ...interface{}) ([]*types.SurveyResponse, error) {
+func (s *SurveyResponseStore) getBySQL(ctx context.Context, query string, args ...any) ([]*types.SurveyResponse, error) {
 	rows, err := s.Handle().DB().QueryContext(ctx, "SELECT id, user_id, email, score, reason, better, created_at FROM survey_responses "+query, args...)
 	if err != nil {
 		return nil, err

--- a/internal/database/testing.go
+++ b/internal/database/testing.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func assertJSONEqual(t *testing.T, want, got interface{}) {
+func assertJSONEqual(t *testing.T, want, got any) {
 	wantJ := asJSON(t, want)
 	gotJ := asJSON(t, got)
 	if wantJ != gotJ {
@@ -13,11 +13,11 @@ func assertJSONEqual(t *testing.T, want, got interface{}) {
 	}
 }
 
-func jsonEqual(t *testing.T, a, b interface{}) bool {
+func jsonEqual(t *testing.T, a, b any) bool {
 	return asJSON(t, a) == asJSON(t, b)
 }
 
-func asJSON(t *testing.T, v interface{}) string {
+func asJSON(t *testing.T, v any) string {
 	b, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/database/user_credentials.go
+++ b/internal/database/user_credentials.go
@@ -94,7 +94,7 @@ const (
 
 // UserCredentialNotFoundErr is returned when a credential cannot be found from
 // its ID or scope.
-type UserCredentialNotFoundErr struct{ args []interface{} }
+type UserCredentialNotFoundErr struct{ args []any }
 
 func (err UserCredentialNotFoundErr) Error() string {
 	return fmt.Sprintf("user credential not found: %v", err.args)
@@ -230,7 +230,7 @@ func (s *UserCredentialsStore) Delete(ctx context.Context, id int64) error {
 	if rows, err := res.RowsAffected(); err != nil {
 		return err
 	} else if rows == 0 {
-		return UserCredentialNotFoundErr{args: []interface{}{id}}
+		return UserCredentialNotFoundErr{args: []any{id}}
 	}
 
 	return nil
@@ -252,7 +252,7 @@ func (s *UserCredentialsStore) GetByID(ctx context.Context, id int64) (*UserCred
 	cred := UserCredential{key: s.key}
 	row := s.QueryRow(ctx, q)
 	if err := scanUserCredential(&cred, row); err == sql.ErrNoRows {
-		return nil, UserCredentialNotFoundErr{args: []interface{}{id}}
+		return nil, UserCredentialNotFoundErr{args: []any{id}}
 	} else if err != nil {
 		return nil, err
 	}
@@ -279,7 +279,7 @@ func (s *UserCredentialsStore) GetByScope(ctx context.Context, scope UserCredent
 	cred := UserCredential{key: s.key}
 	row := s.QueryRow(ctx, q)
 	if err := scanUserCredential(&cred, row); err == sql.ErrNoRows {
-		return nil, UserCredentialNotFoundErr{args: []interface{}{scope}}
+		return nil, UserCredentialNotFoundErr{args: []any{scope}}
 	} else if err != nil {
 		return nil, err
 	}
@@ -490,7 +490,7 @@ RETURNING %s
 // s is inspired by the BatchChange scanner type, but also matches sql.Row, which
 // is generally used directly in this module.
 func scanUserCredential(cred *UserCredential, s interface {
-	Scan(...interface{}) error
+	Scan(...any) error
 }) error {
 	return s.Scan(
 		&cred.ID,

--- a/internal/database/user_credentials_test.go
+++ b/internal/database/user_credentials_test.go
@@ -363,7 +363,7 @@ func TestUserCredentials_GetByScope(t *testing.T) {
 		if !errors.As(err, &e) {
 			t.Errorf("error is not a userCredentialNotFoundError; got %T: %v", err, err)
 		}
-		if diff := cmp.Diff(e.args, []interface{}{scope}); diff != "" {
+		if diff := cmp.Diff(e.args, []any{scope}); diff != "" {
 			t.Errorf("unexpected args:\n%s", diff)
 		}
 	})

--- a/internal/database/user_emails.go
+++ b/internal/database/user_emails.go
@@ -37,7 +37,7 @@ func (email *UserEmail) NeedsVerificationCoolDown() bool {
 
 // userEmailNotFoundError is the error that is returned when a user email is not found.
 type userEmailNotFoundError struct {
-	args []interface{}
+	args []any
 }
 
 func (err userEmailNotFoundError) Error() string {
@@ -111,7 +111,7 @@ func (s *UserEmailsStore) GetPrimaryEmail(ctx context.Context, id int32) (email 
 	if err := s.Handle().DB().QueryRowContext(ctx, "SELECT email, verified_at IS NOT NULL AS verified FROM user_emails WHERE user_id=$1 AND is_primary",
 		id,
 	).Scan(&email, &verified); err != nil {
-		return "", false, userEmailNotFoundError{[]interface{}{fmt.Sprintf("id %d", id)}}
+		return "", false, userEmailNotFoundError{[]any{fmt.Sprintf("id %d", id)}}
 	}
 	return email, verified, nil
 }
@@ -164,7 +164,7 @@ func (s *UserEmailsStore) Get(ctx context.Context, userID int32, email string) (
 	if err := s.Handle().DB().QueryRowContext(ctx, "SELECT email, verified_at IS NOT NULL AS verified FROM user_emails WHERE user_id=$1 AND email=$2",
 		userID, email,
 	).Scan(&emailCanonicalCase, &verified); err != nil {
-		return "", false, userEmailNotFoundError{[]interface{}{fmt.Sprintf("userID %d email %q", userID, email)}}
+		return "", false, userEmailNotFoundError{[]any{fmt.Sprintf("userID %d email %q", userID, email)}}
 	}
 	return emailCanonicalCase, verified, nil
 }
@@ -293,7 +293,7 @@ LIMIT 1
 	if err != nil {
 		return nil, err
 	} else if len(emails) < 1 {
-		return nil, userEmailNotFoundError{[]interface{}{fmt.Sprintf("email %q", email)}}
+		return nil, userEmailNotFoundError{[]any{fmt.Sprintf("email %q", email)}}
 	}
 	return emails[0], nil
 }
@@ -343,7 +343,7 @@ func (s *UserEmailsStore) ListByUser(ctx context.Context, opt UserEmailsListOpti
 }
 
 // getBySQL returns user emails matching the SQL query, if any exist.
-func (s *UserEmailsStore) getBySQL(ctx context.Context, query string, args ...interface{}) ([]*UserEmail, error) {
+func (s *UserEmailsStore) getBySQL(ctx context.Context, query string, args ...any) ([]*UserEmail, error) {
 	s.ensureStore()
 	rows, err := s.Handle().DB().QueryContext(ctx,
 		`SELECT user_emails.user_id, user_emails.email, user_emails.created_at, user_emails.verification_code,

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -93,7 +93,7 @@ func (u *UserStore) ensureStore() {
 
 // userNotFoundErr is the error that is returned when a user is not found.
 type userNotFoundErr struct {
-	args []interface{}
+	args []any
 }
 
 func (err userNotFoundErr) Error() string {
@@ -107,7 +107,7 @@ func (err userNotFoundErr) NotFound() bool {
 // NewUserNotFoundError returns a new error indicating that the user with the given user ID was not
 // found.
 func NewUserNotFoundError(userID int32) error {
-	return userNotFoundErr{args: []interface{}{"userID", userID}}
+	return userNotFoundErr{args: []any{"userID", userID}}
 }
 
 // errCannotCreateUser is the error that is returned when
@@ -175,7 +175,7 @@ type NewUser struct {
 // username/email and password. If no password is given, a non-builtin auth provider must be used to
 // sign into the account.
 //
-// CREATION OF SITE ADMINS
+// # CREATION OF SITE ADMINS
 //
 // The new user is made to be a site admin if the following are both true: (1) this user would be
 // the first and only user on the server, and (2) the site has not yet been initialized. Otherwise,
@@ -485,7 +485,7 @@ func (u *UserStore) Update(ctx context.Context, id int32, update UserUpdate) (er
 		return err
 	}
 	if nrows == 0 {
-		return userNotFoundErr{args: []interface{}{id}}
+		return userNotFoundErr{args: []any{id}}
 	}
 	return nil
 }
@@ -512,7 +512,7 @@ func (u *UserStore) Delete(ctx context.Context, id int32) (err error) {
 		return err
 	}
 	if rows == 0 {
-		return userNotFoundErr{args: []interface{}{id}}
+		return userNotFoundErr{args: []any{id}}
 	}
 
 	// Release the username so it can be used by another user or org.
@@ -607,7 +607,7 @@ func (u *UserStore) HardDelete(ctx context.Context, id int32) (err error) {
 		return err
 	}
 	if rows == 0 {
-		return userNotFoundErr{args: []interface{}{id}}
+		return userNotFoundErr{args: []any{id}}
 	}
 
 	logUserDeletionEvent(ctx, u.Handle().DB(), id, SecurityEventNameAccountNuked)
@@ -774,7 +774,7 @@ func (u *UserStore) InvalidateSessionsByID(ctx context.Context, id int32) (err e
 		return err
 	}
 	if nrows == 0 {
-		return userNotFoundErr{args: []interface{}{id}}
+		return userNotFoundErr{args: []any{id}}
 	}
 	return nil
 }
@@ -1201,7 +1201,7 @@ func (u *UserStore) SetTag(ctx context.Context, userID int32, tag string, presen
 		return err
 	}
 	if nrows == 0 {
-		return userNotFoundErr{args: []interface{}{userID}}
+		return userNotFoundErr{args: []any{userID}}
 	}
 	return nil
 }
@@ -1218,7 +1218,7 @@ func (u *UserStore) HasTag(ctx context.Context, userID int32, tag string) (bool,
 	err := u.QueryRow(ctx, sqlf.Sprintf("SELECT tags FROM users WHERE id = %s", userID)).Scan(pq.Array(&tags))
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return false, userNotFoundErr{[]interface{}{userID}}
+			return false, userNotFoundErr{[]any{userID}}
 		}
 		return false, err
 	}
@@ -1242,7 +1242,7 @@ func (u *UserStore) Tags(ctx context.Context, userID int32) (map[string]bool, er
 	err := u.QueryRow(ctx, sqlf.Sprintf("SELECT tags FROM users WHERE id = %s", userID)).Scan(pq.Array(&tags))
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return nil, userNotFoundErr{[]interface{}{userID}}
+			return nil, userNotFoundErr{[]any{userID}}
 		}
 		return nil, err
 	}

--- a/internal/debugserver/debug.go
+++ b/internal/debugserver/debug.go
@@ -73,7 +73,7 @@ type Service struct {
 // Dumper is a service which can dump its state for debugging.
 type Dumper interface {
 	// DebugDump returns a snapshot of the current state.
-	DebugDump() interface{}
+	DebugDump() any
 }
 
 // NewServerRoutine returns a background routine that exposes pprof and metrics endpoints.

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -169,7 +169,7 @@ func Lock() {
 		}
 	}
 
-	expvar.Publish("env", expvar.Func(func() interface{} {
+	expvar.Publish("env", expvar.Func(func() any {
 		return env
 	}))
 }

--- a/internal/extsvc/bitbucketcloud/client.go
+++ b/internal/extsvc/bitbucketcloud/client.go
@@ -104,7 +104,7 @@ func (c *Client) Repos(ctx context.Context, pageToken *PageToken, accountName st
 	return repos, next, err
 }
 
-func (c *Client) page(ctx context.Context, path string, qry url.Values, token *PageToken, results interface{}) (*PageToken, error) {
+func (c *Client) page(ctx context.Context, path string, qry url.Values, token *PageToken, results any) (*PageToken, error) {
 	if qry == nil {
 		qry = make(url.Values)
 	}
@@ -122,7 +122,7 @@ func (c *Client) page(ctx context.Context, path string, qry url.Values, token *P
 // API 2.0 pagination renders the full link of next page in the response.
 // See more at https://developer.atlassian.com/bitbucket/api/2/reference/meta/pagination
 // However, for the very first request, use method page instead.
-func (c *Client) reqPage(ctx context.Context, url string, results interface{}) (*PageToken, error) {
+func (c *Client) reqPage(ctx context.Context, url string, results any) (*PageToken, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
@@ -131,7 +131,7 @@ func (c *Client) reqPage(ctx context.Context, url string, results interface{}) (
 	var next PageToken
 	err = c.do(ctx, req, &struct {
 		*PageToken
-		Values interface{} `json:"values"`
+		Values any `json:"values"`
 	}{
 		PageToken: &next,
 		Values:    results,
@@ -144,7 +144,7 @@ func (c *Client) reqPage(ctx context.Context, url string, results interface{}) (
 	return &next, nil
 }
 
-func (c *Client) do(ctx context.Context, req *http.Request, result interface{}) error {
+func (c *Client) do(ctx context.Context, req *http.Request, result any) error {
 	req.URL = c.URL.ResolveReference(req.URL)
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -878,7 +878,7 @@ func (c *Client) RecentRepos(ctx context.Context, pageToken *PageToken) ([]*Repo
 	return repos, next, err
 }
 
-func (c *Client) page(ctx context.Context, path string, qry url.Values, token *PageToken, results interface{}) (*PageToken, error) {
+func (c *Client) page(ctx context.Context, path string, qry url.Values, token *PageToken, results any) (*PageToken, error) {
 	if qry == nil {
 		qry = make(url.Values)
 	}
@@ -896,7 +896,7 @@ func (c *Client) page(ctx context.Context, path string, qry url.Values, token *P
 	var next PageToken
 	_, err = c.do(ctx, req, &struct {
 		*PageToken
-		Values interface{} `json:"values"`
+		Values any `json:"values"`
 	}{
 		PageToken: &next,
 		Values:    results,
@@ -909,7 +909,7 @@ func (c *Client) page(ctx context.Context, path string, qry url.Values, token *P
 	return &next, nil
 }
 
-func (c *Client) send(ctx context.Context, method, path string, qry url.Values, payload, result interface{}) (*http.Response, error) {
+func (c *Client) send(ctx context.Context, method, path string, qry url.Values, payload, result any) (*http.Response, error) {
 	if qry == nil {
 		qry = make(url.Values)
 	}
@@ -931,7 +931,7 @@ func (c *Client) send(ctx context.Context, method, path string, qry url.Values, 
 	return c.do(ctx, req, result)
 }
 
-func (c *Client) do(ctx context.Context, req *http.Request, result interface{}) (*http.Response, error) {
+func (c *Client) do(ctx context.Context, req *http.Request, result any) (*http.Response, error) {
 	req.URL = c.URL.ResolveReference(req.URL)
 	if req.Header.Get("Content-Type") == "" {
 		req.Header.Set("Content-Type", "application/json; charset=utf-8")
@@ -1492,7 +1492,7 @@ func (c *Client) CreatePullRequestComment(ctx context.Context, pr *PullRequest, 
 
 	qry := url.Values{"version": {strconv.Itoa(pr.Version)}}
 
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"text": body,
 	}
 

--- a/internal/extsvc/bitbucketserver/client_test.go
+++ b/internal/extsvc/bitbucketserver/client_test.go
@@ -1057,7 +1057,7 @@ func TestClient_RepoIDs(t *testing.T) {
 	checkGolden(t, "RepoIDs", ids)
 }
 
-func checkGolden(t *testing.T, name string, got interface{}) {
+func checkGolden(t *testing.T, name string, got any) {
 	t.Helper()
 
 	data, err := json.MarshalIndent(got, " ", " ")

--- a/internal/extsvc/bitbucketserver/events.go
+++ b/internal/extsvc/bitbucketserver/events.go
@@ -17,7 +17,7 @@ func WebhookEventType(r *http.Request) string {
 	return r.Header.Get(eventTypeHeader)
 }
 
-func ParseWebhookEvent(eventType string, payload []byte) (e interface{}, err error) {
+func ParseWebhookEvent(eventType string, payload []byte) (e any, err error) {
 	switch eventType {
 	case "ping":
 		return PingEvent{}, nil

--- a/internal/extsvc/data.go
+++ b/internal/extsvc/data.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-func setJSONOrError(field **json.RawMessage, value interface{}) {
+func setJSONOrError(field **json.RawMessage, value any) {
 	if value == nil {
 		*field = nil
 		return
@@ -23,29 +23,29 @@ func setJSONOrError(field **json.RawMessage, value interface{}) {
 
 // SetAccountData sets the Data field to the (JSON-encoded) value. If an error occurs during
 // JSON encoding, a JSON object describing the error is written to the field, instead.
-func (d *AccountData) SetAccountData(v interface{}) {
+func (d *AccountData) SetAccountData(v any) {
 	setJSONOrError(&d.Data, v)
 }
 
 // SetAuthData sets the AuthData field to the (JSON-encoded) value. If an error occurs during JSON
 // encoding, a JSON object describing the error is written to the field, instead.
-func (d *AccountData) SetAuthData(v interface{}) {
+func (d *AccountData) SetAuthData(v any) {
 	setJSONOrError(&d.AuthData, v)
 }
 
 // GetAccountData reads the Data field into the value. The value should be a pointer type to
 // the type that was passed to SetAccountData.
-func (d *AccountData) GetAccountData(v interface{}) error {
+func (d *AccountData) GetAccountData(v any) error {
 	return getJSONOrError(d.Data, v)
 }
 
 // GetAuthData reads the AuthData field into the value. The value should be a pointer type to the
 // type that was passed to SetAuthData.
-func (d *AccountData) GetAuthData(v interface{}) error {
+func (d *AccountData) GetAuthData(v any) error {
 	return getJSONOrError(d.AuthData, v)
 }
 
-func getJSONOrError(field *json.RawMessage, v interface{}) error {
+func getJSONOrError(field *json.RawMessage, v any) error {
 	if field == nil {
 		return errors.New("field was nil")
 	}

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -444,7 +444,7 @@ type TimelineItemConnection struct {
 // TimelineItem is a union type of all supported pull request timeline items.
 type TimelineItem struct {
 	Type string
-	Item interface{}
+	Item any
 }
 
 // UnmarshalJSON knows how to unmarshal a TimelineItem as produced
@@ -555,7 +555,7 @@ func (c *V4Client) CreatePullRequest(ctx context.Context, in *CreatePullRequestI
 		} `json:"createPullRequest"`
 	}
 
-	compatibleInput := map[string]interface{}{
+	compatibleInput := map[string]any{
 		"repositoryId": in.RepositoryID,
 		"baseRefName":  in.BaseRefName,
 		"headRefName":  in.HeadRefName,
@@ -569,7 +569,7 @@ func (c *V4Client) CreatePullRequest(ctx context.Context, in *CreatePullRequestI
 		return nil, errors.New("draft PRs not supported by this version of GitHub enterprise. GitHub Enterprise v3.21 is the first version to support draft PRs.\nPotential fix: set `published: true` in your batch spec.")
 	}
 
-	input := map[string]interface{}{"input": compatibleInput}
+	input := map[string]any{"input": compatibleInput}
 	err = c.requestGraphQL(ctx, q.String(), input, &result)
 	if err != nil {
 		var errs graphqlErrors
@@ -632,7 +632,7 @@ func (c *V4Client) UpdatePullRequest(ctx context.Context, in *UpdatePullRequestI
 		} `json:"updatePullRequest"`
 	}
 
-	input := map[string]interface{}{"input": in}
+	input := map[string]any{"input": in}
 	err = c.requestGraphQL(ctx, q.String(), input, &result)
 	if err != nil {
 		var errs graphqlErrors
@@ -683,7 +683,7 @@ func (c *V4Client) MarkPullRequestReadyForReview(ctx context.Context, pr *PullRe
 		} `json:"markPullRequestReadyForReview"`
 	}
 
-	input := map[string]interface{}{"input": struct {
+	input := map[string]any{"input": struct {
 		ID string `json:"pullRequestId"`
 	}{ID: pr.ID}}
 	err = c.requestGraphQL(ctx, q.String(), input, &result)
@@ -732,7 +732,7 @@ func (c *V4Client) ClosePullRequest(ctx context.Context, pr *PullRequest) error 
 		} `json:"closePullRequest"`
 	}
 
-	input := map[string]interface{}{"input": struct {
+	input := map[string]any{"input": struct {
 		ID string `json:"pullRequestId"`
 	}{ID: pr.ID}}
 	err = c.requestGraphQL(ctx, q.String(), input, &result)
@@ -781,7 +781,7 @@ func (c *V4Client) ReopenPullRequest(ctx context.Context, pr *PullRequest) error
 		} `json:"reopenPullRequest"`
 	}
 
-	input := map[string]interface{}{"input": struct {
+	input := map[string]any{"input": struct {
 		ID string `json:"pullRequestId"`
 	}{ID: pr.ID}}
 	err = c.requestGraphQL(ctx, q.String(), input, &result)
@@ -834,7 +834,7 @@ query($owner: String!, $name: String!, $number: Int!) {
 		}
 	}
 
-	err = c.requestGraphQL(ctx, q, map[string]interface{}{"owner": owner, "name": repo, "number": pr.Number}, &result)
+	err = c.requestGraphQL(ctx, q, map[string]any{"owner": owner, "name": repo, "number": pr.Number}, &result)
 	if err != nil {
 		var errs graphqlErrors
 		if errors.As(err, &errs) {
@@ -941,7 +941,7 @@ func (c *V4Client) CreatePullRequestComment(ctx context.Context, pr *PullRequest
 		} `json:"addComment"`
 	}
 
-	input := map[string]interface{}{"input": struct {
+	input := map[string]any{"input": struct {
 		SubjectID string `json:"subjectId"`
 		Body      string `json:"body"`
 	}{SubjectID: pr.ID, Body: body}}
@@ -980,7 +980,7 @@ func (c *V4Client) MergePullRequest(ctx context.Context, pr *PullRequest, squash
 	if squash {
 		mergeMethod = "SQUASH"
 	}
-	input := map[string]interface{}{"input": struct {
+	input := map[string]any{"input": struct {
 		PullRequestID string `json:"pullRequestId"`
 		MergeMethod   string `json:"mergeMethod,omitempty"`
 	}{
@@ -1468,7 +1468,7 @@ func APIRoot(baseURL *url.URL) (apiURL *url.URL, githubDotCom bool) {
 	return baseURL.ResolveReference(&url.URL{Path: "api"}), false
 }
 
-func doRequest(ctx context.Context, apiURL *url.URL, auth auth.Authenticator, rateLimitMonitor *ratelimit.Monitor, httpClient httpcli.Doer, req *http.Request, result interface{}) (headers http.Header, err error) {
+func doRequest(ctx context.Context, apiURL *url.URL, auth auth.Authenticator, rateLimitMonitor *ratelimit.Monitor, httpClient httpcli.Doer, req *http.Request, result any) (headers http.Header, err error) {
 	req.URL.Path = path.Join(apiURL.Path, req.URL.Path)
 	req.URL = apiURL.ResolveReference(req.URL)
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")

--- a/internal/extsvc/github/v3.go
+++ b/internal/extsvc/github/v3.go
@@ -128,16 +128,16 @@ func (c *V3Client) RateLimitMonitor() *ratelimit.Monitor {
 	return c.rateLimitMonitor
 }
 
-func (c *V3Client) requestGet(ctx context.Context, requestURI string, result interface{}) error {
+func (c *V3Client) requestGet(ctx context.Context, requestURI string, result any) error {
 	_, err := c.get(ctx, requestURI, result)
 	return err
 }
 
-func (c *V3Client) requestGetWithHeader(ctx context.Context, requestURI string, result interface{}) (http.Header, error) {
+func (c *V3Client) requestGetWithHeader(ctx context.Context, requestURI string, result any) (http.Header, error) {
 	return c.get(ctx, requestURI, result)
 }
 
-func (c *V3Client) get(ctx context.Context, requestURI string, result interface{}) (http.Header, error) {
+func (c *V3Client) get(ctx context.Context, requestURI string, result any) (http.Header, error) {
 	req, err := http.NewRequest("GET", requestURI, nil)
 	if err != nil {
 		return nil, err
@@ -219,7 +219,7 @@ func (c *V3Client) GetVersion(ctx context.Context) (string, error) {
 		return "unknown", nil
 	}
 
-	var empty interface{}
+	var empty any
 
 	header, err := c.requestGetWithHeader(ctx, "/", &empty)
 	if err != nil {

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -106,10 +106,10 @@ func (c *V4Client) RateLimitMonitor() *ratelimit.Monitor {
 	return c.rateLimitMonitor
 }
 
-func (c *V4Client) requestGraphQL(ctx context.Context, query string, vars map[string]interface{}, result interface{}) (err error) {
+func (c *V4Client) requestGraphQL(ctx context.Context, query string, vars map[string]any, result any) (err error) {
 	reqBody, err := json.Marshal(struct {
-		Query     string                 `json:"query"`
-		Variables map[string]interface{} `json:"variables"`
+		Query     string         `json:"query"`
+		Variables map[string]any `json:"variables"`
 	}{
 		Query:     query,
 		Variables: vars,
@@ -202,7 +202,7 @@ func calcDefinitionCost(def ast.Node) int {
 	limitStack := make([]limitDepth, 0)
 
 	v := &visitor.VisitorOptions{
-		Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+		Enter: func(p visitor.VisitFuncParams) (string, any) {
 			switch node := p.Node.(type) {
 			case *ast.IntValue:
 				// We're looking for a 'first' or 'last' param indicating a limit
@@ -266,9 +266,9 @@ func filterInPlace(limitStack []limitDepth, depth int) []limitDepth {
 // graphqlErrors describes the errors in a GraphQL response. It contains at least 1 element when returned by
 // requestGraphQL. See https://graphql.github.io/graphql-spec/June2018/#sec-Errors.
 type graphqlErrors []struct {
-	Message   string        `json:"message"`
-	Type      string        `json:"type"`
-	Path      []interface{} `json:"path"`
+	Message   string `json:"message"`
+	Type      string `json:"type"`
+	Path      []any  `json:"path"`
 	Locations []struct {
 		Line   int `json:"line"`
 		Column int `json:"column"`
@@ -283,7 +283,7 @@ func (e graphqlErrors) Error() string {
 
 // unmarshal wraps json.Unmarshal, but includes extra context in the case of
 // json.UnmarshalTypeError
-func unmarshal(data []byte, v interface{}) error {
+func unmarshal(data []byte, v any) error {
 	err := json.Unmarshal(data, v)
 	var e *json.UnmarshalTypeError
 	if errors.As(err, &e) && e.Offset >= 0 {
@@ -398,7 +398,7 @@ func (c *V4Client) SearchRepos(ctx context.Context, p SearchReposParams) (Search
 		p.First = 100
 	}
 
-	vars := map[string]interface{}{
+	vars := map[string]any{
 		"query": p.Query,
 		"type":  "REPOSITORY",
 		"first": p.First,
@@ -474,7 +474,7 @@ func (c *V4Client) GetReposByNameWithOwner(ctx context.Context, namesWithOwners 
 	}
 
 	var result map[string]*Repository
-	err = c.requestGraphQL(ctx, query, map[string]interface{}{}, &result)
+	err = c.requestGraphQL(ctx, query, map[string]any{}, &result)
 	if err != nil {
 		var e graphqlErrors
 		if errors.As(err, &e) {

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -50,7 +50,7 @@ func init() {
 	}()
 }
 
-func trace(msg string, ctx ...interface{}) {
+func trace(msg string, ctx ...any) {
 	if atomic.LoadInt32(&traceEnabled) == 1 {
 		log15.Info(fmt.Sprintf("TRACE %s", msg), ctx...)
 	}
@@ -212,13 +212,13 @@ func isGitLabDotComURL(baseURL *url.URL) bool {
 
 // do is the default method for making API requests and will prepare the correct
 // base path.
-func (c *Client) do(ctx context.Context, req *http.Request, result interface{}) (responseHeader http.Header, responseCode int, err error) {
+func (c *Client) do(ctx context.Context, req *http.Request, result any) (responseHeader http.Header, responseCode int, err error) {
 	req.URL = c.baseURL.ResolveReference(req.URL)
 	return c.doWithBaseURL(ctx, req, result)
 }
 
 // doWithBaseURL will not amend the request URL.
-func (c *Client) doWithBaseURL(ctx context.Context, req *http.Request, result interface{}) (responseHeader http.Header, responseCode int, err error) {
+func (c *Client) doWithBaseURL(ctx context.Context, req *http.Request, result any) (responseHeader http.Header, responseCode int, err error) {
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	if c.Auth != nil {
 		if err := c.Auth.Authenticate(req); err != nil {

--- a/internal/extsvc/gitlab/resource_state_events.go
+++ b/internal/extsvc/gitlab/resource_state_events.go
@@ -104,7 +104,7 @@ func (e *MergeRequestMergedEvent) Key() string {
 
 // ToEvent returns a pointer to a more specific struct, or
 // nil if the ResourceStateEvent is not of a known kind.
-func (rse *ResourceStateEvent) ToEvent() interface{} {
+func (rse *ResourceStateEvent) ToEvent() any {
 	switch rse.State {
 	case ResourceStateEventStateClosed:
 		return &MergeRequestClosedEvent{rse}

--- a/internal/extsvc/gitlab/webhooks/events.go
+++ b/internal/extsvc/gitlab/webhooks/events.go
@@ -28,7 +28,7 @@ type PipelineEvent struct {
 var ErrObjectKindUnknown = errors.New("unknown object kind")
 
 type downcaster interface {
-	downcast() (interface{}, error)
+	downcast() (any, error)
 }
 
 // UnmarshalEvent unmarshals the given JSON into an event type. Possible return
@@ -38,7 +38,7 @@ type downcaster interface {
 // distinguished from other errors by checking for ErrObjectKindUnknown in the
 // error chain; note that the top level error value will not be equal to
 // ErrObjectKindUnknown in this case.
-func UnmarshalEvent(data []byte) (interface{}, error) {
+func UnmarshalEvent(data []byte) (any, error) {
 	// We need to unmarshal the event twice: once to determine what the eventual
 	// return type should be, and then once to actual unmarshal into that type.
 	//
@@ -54,7 +54,7 @@ func UnmarshalEvent(data []byte) (interface{}, error) {
 	}
 
 	// Now we can set up the typed event that we'll unmarshal into.
-	var typedEvent interface{}
+	var typedEvent any
 	switch event.ObjectKind {
 	case "merge_request":
 		typedEvent = &mergeRequestEvent{}

--- a/internal/extsvc/gitlab/webhooks/merge_requests.go
+++ b/internal/extsvc/gitlab/webhooks/merge_requests.go
@@ -207,7 +207,7 @@ type mergeRequestEventObjectAttributes struct {
 	Action string `json:"action"`
 }
 
-func (mre *mergeRequestEvent) downcast() (interface{}, error) {
+func (mre *mergeRequestEvent) downcast() (any, error) {
 	e := MergeRequestEventCommon{
 		EventCommon:  mre.EventCommon,
 		MergeRequest: mre.ObjectAttributes.MergeRequest,

--- a/internal/extsvc/phabricator/client.go
+++ b/internal/extsvc/phabricator/client.go
@@ -31,8 +31,8 @@ type meteredConn struct {
 func (mc *meteredConn) CallContext(
 	ctx context.Context,
 	method string,
-	params interface{},
-	result interface{},
+	params any,
+	result any,
 ) error {
 	start := time.Now()
 	err := mc.Conn.CallContext(ctx, method, params, result)

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -265,7 +265,7 @@ type RepoID string
 type RepoIDType string
 
 // ParseConfig attempts to unmarshal the given JSON config into a configuration struct defined in the schema package.
-func ParseConfig(kind, config string) (cfg interface{}, _ error) {
+func ParseConfig(kind, config string) (cfg any, _ error) {
 	switch strings.ToUpper(kind) {
 	case KindAWSCodeCommit:
 		cfg = &schema.AWSCodeCommitConnection{}
@@ -357,7 +357,7 @@ type RateLimitConfig struct {
 }
 
 // GetLimitFromConfig gets RateLimitConfig from an already parsed config schema.
-func GetLimitFromConfig(kind string, config interface{}) (rlc RateLimitConfig, err error) {
+func GetLimitFromConfig(kind string, config any) (rlc RateLimitConfig, err error) {
 	// Rate limit config can be in a few states:
 	// 1. Not defined: We fall back to default specified in code.
 	// 2. Defined and enabled: We use their defined limit.

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -902,13 +902,13 @@ func (c *Client) Remove(ctx context.Context, repo api.RepoName) error {
 	return nil
 }
 
-func (c *Client) httpPost(ctx context.Context, repo api.RepoName, op string, payload interface{}) (resp *http.Response, err error) {
+func (c *Client) httpPost(ctx context.Context, repo api.RepoName, op string, payload any) (resp *http.Response, err error) {
 	return c.do(ctx, repo, "POST", op, payload)
 }
 
 // do performs a request to a gitserver, sharding based on the given
 // repo name (the repo name is otherwise not used).
-func (c *Client) do(ctx context.Context, repo api.RepoName, method, op string, payload interface{}) (resp *http.Response, err error) {
+func (c *Client) do(ctx context.Context, repo api.RepoName, method, op string, payload any) (resp *http.Response, err error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "Client.do")
 	defer func() {
 		span.LogKV("repo", string(repo), "method", method, "op", op)

--- a/internal/goroutine/mock_background_routine_test.go
+++ b/internal/goroutine/mock_background_routine_test.go
@@ -135,14 +135,14 @@ type BackgroundRoutineStartFuncCall struct{}
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c BackgroundRoutineStartFuncCall) Args() []interface{} {
-	return []interface{}{}
+func (c BackgroundRoutineStartFuncCall) Args() []any {
+	return []any{}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c BackgroundRoutineStartFuncCall) Results() []interface{} {
-	return []interface{}{}
+func (c BackgroundRoutineStartFuncCall) Results() []any {
+	return []any{}
 }
 
 // BackgroundRoutineStopFunc describes the behavior when the Stop method of
@@ -231,12 +231,12 @@ type BackgroundRoutineStopFuncCall struct{}
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c BackgroundRoutineStopFuncCall) Args() []interface{} {
-	return []interface{}{}
+func (c BackgroundRoutineStopFuncCall) Args() []any {
+	return []any{}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c BackgroundRoutineStopFuncCall) Results() []interface{} {
-	return []interface{}{}
+func (c BackgroundRoutineStopFuncCall) Results() []any {
+	return []any{}
 }

--- a/internal/goroutine/mock_error_handler_test.go
+++ b/internal/goroutine/mock_error_handler_test.go
@@ -126,12 +126,12 @@ type ErrorHandlerHandleErrorFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c ErrorHandlerHandleErrorFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c ErrorHandlerHandleErrorFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c ErrorHandlerHandleErrorFuncCall) Results() []interface{} {
-	return []interface{}{}
+func (c ErrorHandlerHandleErrorFuncCall) Results() []any {
+	return []any{}
 }

--- a/internal/goroutine/mock_finalizer_test.go
+++ b/internal/goroutine/mock_finalizer_test.go
@@ -120,12 +120,12 @@ type FinalizerOnShutdownFuncCall struct{}
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c FinalizerOnShutdownFuncCall) Args() []interface{} {
-	return []interface{}{}
+func (c FinalizerOnShutdownFuncCall) Args() []any {
+	return []any{}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c FinalizerOnShutdownFuncCall) Results() []interface{} {
-	return []interface{}{}
+func (c FinalizerOnShutdownFuncCall) Results() []any {
+	return []any{}
 }

--- a/internal/goroutine/mock_handler_test.go
+++ b/internal/goroutine/mock_handler_test.go
@@ -130,12 +130,12 @@ type HandlerHandleFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c HandlerHandleFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c HandlerHandleFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c HandlerHandleFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c HandlerHandleFuncCall) Results() []any {
+	return []any{c.Result0}
 }

--- a/internal/gqltestutil/access_token.go
+++ b/internal/gqltestutil/access_token.go
@@ -14,7 +14,7 @@ mutation CreateAccessToken($user: ID!, $scopes: [String!]!, $note: String!) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"user":   c.userID,
 		"scopes": scopes,
 		"note":   note,
@@ -42,7 +42,7 @@ mutation DeleteAccessToken($token: String!) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"token": token,
 	}
 	err := c.GraphQL("", query, variables, nil)

--- a/internal/gqltestutil/client.go
+++ b/internal/gqltestutil/client.go
@@ -59,7 +59,7 @@ func SignIn(baseURL, email, password string) (*Client, error) {
 }
 
 // authenticate initializes an authenticated client with given request body.
-func authenticate(baseURL, path string, body interface{}) (*Client, error) {
+func authenticate(baseURL, path string, body any) (*Client, error) {
 	client, err := newClient(baseURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "new client")
@@ -140,7 +140,7 @@ func newClient(baseURL string) (*Client, error) {
 // authenticate is used to send a HTTP POST request to an URL that is able to authenticate
 // a user with given body (marshalled to JSON), e.g. site admin init, sign in. Once the
 // client is authenticated, the session cookie will be stored as a proof of authentication.
-func (c *Client) authenticate(path string, body interface{}) error {
+func (c *Client) authenticate(path string, body any) error {
 	p, err := jsoniter.Marshal(body)
 	if err != nil {
 		return errors.Wrap(err, "marshal body")
@@ -223,8 +223,8 @@ var graphqlQueryNameRe = lazyregexp.New(`(query|mutation) +(\w)+`)
 // GraphQL makes a GraphQL request to the server on behalf of the user authenticated by the client.
 // An optional token can be passed to impersonate other users. A nil target will skip unmarshalling
 // the returned JSON response.
-func (c *Client) GraphQL(token, query string, variables map[string]interface{}, target interface{}) error {
-	body, err := jsoniter.Marshal(map[string]interface{}{
+func (c *Client) GraphQL(token, query string, variables map[string]any, target any) error {
+	body, err := jsoniter.Marshal(map[string]any{
 		"query":     query,
 		"variables": variables,
 	})

--- a/internal/gqltestutil/external_service.go
+++ b/internal/gqltestutil/external_service.go
@@ -23,7 +23,7 @@ mutation AddExternalService($input: AddExternalServiceInput!) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": input,
 	}
 	var resp struct {
@@ -57,7 +57,7 @@ mutation DeleteExternalService($externalService: ID!) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"externalService": id,
 	}
 	err := c.GraphQL("", query, variables, nil)

--- a/internal/gqltestutil/git_blob.go
+++ b/internal/gqltestutil/git_blob.go
@@ -17,7 +17,7 @@ query Blob($repoName: String!, $revision: String!, $filePath: String!) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"repoName": repoName,
 		"revision": revision,
 		"filePath": filePath,

--- a/internal/gqltestutil/organization.go
+++ b/internal/gqltestutil/organization.go
@@ -20,7 +20,7 @@ query Organization($name: String!) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"name": name,
 	}
 	var resp struct {
@@ -58,7 +58,7 @@ query OrganizationMembers($id: ID!) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"id": id,
 	}
 	var resp struct {
@@ -96,7 +96,7 @@ mutation InviteUserToOrganization($organization: ID!, $username: String!) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"organization": orgID,
 		"username":     username,
 	}
@@ -122,7 +122,7 @@ mutation CreateOrganization($name: String!, $displayName: String) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"name":        name,
 		"displayName": displayName,
 	}
@@ -149,7 +149,7 @@ mutation UpdateOrganization($id: ID!, $displayName: String) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"id":          id,
 		"displayName": displayName,
 	}
@@ -172,7 +172,7 @@ mutation DeleteOrganization($organization: ID!) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"organization": id,
 	}
 	err := c.GraphQL("", query, variables, nil)
@@ -191,7 +191,7 @@ mutation RemoveUserFromOrganization($user: ID!, $organization: ID!) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"user":         userID,
 		"organization": orgID,
 	}

--- a/internal/gqltestutil/permissions.go
+++ b/internal/gqltestutil/permissions.go
@@ -12,7 +12,7 @@ mutation ScheduleRepositoryPermissionsSync($repository: ID!) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"repository": id,
 	}
 	err := c.GraphQL("", query, variables, nil)

--- a/internal/gqltestutil/repository.go
+++ b/internal/gqltestutil/repository.go
@@ -146,7 +146,7 @@ query FileExternalLinks($repoName: String!, $revision: String!, $filePath: Strin
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"repoName": repoName,
 		"revision": revision,
 		"filePath": filePath,
@@ -186,7 +186,7 @@ query Repository($name: String!) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"name": name,
 	}
 	var resp struct {
@@ -224,7 +224,7 @@ query RepositoryPermissionsInfo($name: String!) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"name": name,
 	}
 	var resp struct {

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -60,7 +60,7 @@ query Search($query: String!) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"query": query,
 	}
 	var resp struct {
@@ -152,7 +152,7 @@ query Search($query: String!) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"query": query,
 	}
 	var resp struct {
@@ -196,7 +196,7 @@ query Search($query: String!) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"query": query,
 	}
 	var resp struct {
@@ -217,7 +217,7 @@ query Search($query: String!) {
 }
 
 type AnyResult struct {
-	Inner interface{}
+	Inner any
 }
 
 func (r *AnyResult) UnmarshalJSON(b []byte) error {
@@ -262,7 +262,7 @@ type FileResult struct {
 	LineMatches []struct {
 		OffsetAndLengths [][2]int32 `json:"offsetAndLengths"`
 	} `json:"lineMatches"`
-	Symbols []interface{} `json:"symbols"`
+	Symbols []any `json:"symbols"`
 }
 
 type CommitResult struct {
@@ -307,7 +307,7 @@ query Search($query: String!) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"query": query,
 	}
 	var resp struct {
@@ -348,7 +348,7 @@ query SearchResultsStats($query: String!) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"query": query,
 	}
 	var resp struct {
@@ -367,7 +367,7 @@ query SearchResultsStats($query: String!) {
 }
 
 type SearchSuggestionsResult struct {
-	inner interface{}
+	inner any
 }
 
 func (srr *SearchSuggestionsResult) UnmarshalJSON(data []byte) error {
@@ -502,7 +502,7 @@ query SearchSuggestions($query: String!) {
 	}
 }`
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"query": query,
 	}
 
@@ -606,7 +606,7 @@ func (s *SearchStreamClient) SearchFiles(query string) (*SearchFileResults, erro
 	return &results, err
 }
 func (s *SearchStreamClient) SearchAll(query string) ([]*AnyResult, error) {
-	var results []interface{}
+	var results []any
 	err := s.search(query, streamhttp.Decoder{
 		OnMatches: func(matches []streamhttp.EventMatch) {
 			for _, m := range matches {
@@ -639,7 +639,7 @@ func (s *SearchStreamClient) SearchAll(query string) ([]*AnyResult, error) {
 					var r FileResult
 					r.File.Path = v.Path
 					r.Repository.Name = v.Repository
-					r.Symbols = make([]interface{}, len(v.Symbols))
+					r.Symbols = make([]any, len(v.Symbols))
 					results = append(results, &r)
 
 				case *streamhttp.EventCommitMatch:

--- a/internal/gqltestutil/search_context.go
+++ b/internal/gqltestutil/search_context.go
@@ -33,7 +33,7 @@ mutation CreateSearchContext($input: SearchContextInput!, $repositories: [Search
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input":        input,
 		"repositories": repositories,
 	}
@@ -84,7 +84,7 @@ query GetSearchContext($id: ID!) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"id": id,
 	}
 	var resp struct {
@@ -117,7 +117,7 @@ mutation UpdateSearchContext($id: ID!, $input: SearchContextEditInput!, $reposit
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"id":           id,
 		"input":        input,
 		"repositories": repos,
@@ -146,7 +146,7 @@ mutation DeleteSearchContext($id: ID!) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"id": id,
 	}
 	err := c.GraphQL("", query, variables, nil)
@@ -225,7 +225,7 @@ query ListSearchContexts(
 		orderBy = *options.OrderBy
 	}
 
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"first":      options.First,
 		"after":      options.After,
 		"query":      options.Query,

--- a/internal/gqltestutil/settings.go
+++ b/internal/gqltestutil/settings.go
@@ -30,7 +30,7 @@ query SettingsCascade($subject: ID!) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"subject": subjectID,
 	}
 	var resp struct {
@@ -67,7 +67,7 @@ mutation OverwriteSettings($subject: ID!, $lastID: Int, $contents: String!) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"subject":  subjectID,
 		"lastID":   lastID,
 		"contents": contents,
@@ -199,7 +199,7 @@ mutation UpdateSiteConfiguration($input: String!) {
 	updateSiteConfiguration(lastID: 0, input: $input)
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"input": string(input),
 	}
 	err = c.GraphQL("", query, variables, nil)

--- a/internal/gqltestutil/user.go
+++ b/internal/gqltestutil/user.go
@@ -18,7 +18,7 @@ mutation CreateUser($username: String!, $email: String) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"username": username,
 		"email":    email,
 	}
@@ -50,7 +50,7 @@ mutation DeleteUser($user: ID!, $hard: Boolean) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"user": id,
 		"hard": hard,
 	}
@@ -74,7 +74,7 @@ query User($username: String) {
 	}
 }
 `
-	variables := map[string]interface{}{
+	variables := map[string]any{
 		"username": username,
 	}
 	var resp struct {

--- a/internal/honey/honey.go
+++ b/internal/honey/honey.go
@@ -28,7 +28,7 @@ func Event(dataset string) *libhoney.Event {
 
 // EventWithFields creates an event for logging to the given dataset. The given
 // fields are assigned to the event.
-func EventWithFields(dataset string, fields map[string]interface{}) *libhoney.Event {
+func EventWithFields(dataset string, fields map[string]any) *libhoney.Event {
 	ev := Event(dataset)
 	for key, value := range fields {
 		ev.AddField(key, value)

--- a/internal/httptestutil/client.go
+++ b/internal/httptestutil/client.go
@@ -98,11 +98,11 @@ func (c Client) GetNoFollowRedirects(url_ string) (*http.Response, error) {
 	return c.DoNoFollowRedirects(req)
 }
 
-func (c *Client) GetJSON(url string, v interface{}) error {
+func (c *Client) GetJSON(url string, v any) error {
 	return c.DoJSON("GET", url, nil, v)
 }
 
-func (c *Client) DoJSON(method, url string, in, out interface{}) error {
+func (c *Client) DoJSON(method, url string, in, out any) error {
 	var reqBody io.Reader
 	if in != nil {
 		b, err := json.Marshal(in)

--- a/internal/insights/mock_loader.go
+++ b/internal/insights/mock_loader.go
@@ -133,12 +133,12 @@ type LoaderLoadAllFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c LoaderLoadAllFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c LoaderLoadAllFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c LoaderLoadAllFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c LoaderLoadAllFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }

--- a/internal/inventory/inventory_test.go
+++ b/internal/inventory/inventory_test.go
@@ -107,8 +107,8 @@ func (f fi) ModTime() time.Time {
 	return time.Now()
 }
 
-func (f fi) Sys() interface{} {
-	return interface{}(nil)
+func (f fi) Sys() any {
+	return any(nil)
 }
 
 func TestGet_readFile(t *testing.T) {

--- a/internal/jsonc/jsonc.go
+++ b/internal/jsonc/jsonc.go
@@ -11,7 +11,7 @@ import (
 
 // Unmarshal unmarshals the JSON using a fault-tolerant parser that allows comments and trailing
 // commas. If any unrecoverable faults are found, an error is returned.
-func Unmarshal(text string, v interface{}) error {
+func Unmarshal(text string, v any) error {
 	data, err := Parse(text)
 	if err != nil {
 		return err
@@ -58,7 +58,7 @@ func Remove(input string, path ...string) (string, error) {
 }
 
 // Edit returns the input JSON with the given path set to v.
-func Edit(input string, v interface{}, path ...string) (string, error) {
+func Edit(input string, v any, path ...string) (string, error) {
 	edits, _, err := jsonx.ComputePropertyEdit(input,
 		jsonx.PropertyPath(path...),
 		v,
@@ -74,7 +74,7 @@ func Edit(input string, v interface{}, path ...string) (string, error) {
 
 // ReadProperty attempts to read the value of the specified path, ignoring parse errors. it will only error if the path
 // doesn't exist
-func ReadProperty(input, path string) (interface{}, error) {
+func ReadProperty(input, path string) (any, error) {
 	root, _ := jsonx.ParseTree(input, jsonx.ParseOptions{Comments: true, TrailingCommas: true})
 	node := jsonx.FindNodeAtLocation(root, jsonx.PropertyPath(path))
 	if node == nil {

--- a/internal/jsonc/jsonc_test.go
+++ b/internal/jsonc/jsonc_test.go
@@ -12,9 +12,9 @@ func TestUnmarshal(t *testing.T) {
 /* another comment */
 "hello": "world",
 }`
-	want := map[string]interface{}{"hello": "world"}
+	want := map[string]any{"hello": "world"}
 
-	var got interface{}
+	var got any
 	if err := Unmarshal(input, &got); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -2,14 +2,14 @@ package logging
 
 // ErrorLogger captures the method required for logging an error.
 type ErrorLogger interface {
-	Error(msg string, ctx ...interface{})
+	Error(msg string, ctx ...any)
 }
 
 // Log logs the given message and context when the given error is defined.
-func Log(lg ErrorLogger, msg string, err *error, ctx ...interface{}) {
+func Log(lg ErrorLogger, msg string, err *error, ctx ...any) {
 	if lg == nil || err == nil || *err == nil {
 		return
 	}
 
-	lg.Error(msg, append(append(make([]interface{}, 0, 2+len(ctx)), "error", *err), ctx...)...)
+	lg.Error(msg, append(append(make([]any, 0, 2+len(ctx)), "error", *err), ctx...)...)
 }

--- a/internal/observation/observation.go
+++ b/internal/observation/observation.go
@@ -2,48 +2,48 @@
 //
 // High-level ideas:
 //
-//     - Each service creates an observation Context that carries a root logger, tracer,
-//       and a metrics registerer as its context.
+//   - Each service creates an observation Context that carries a root logger, tracer,
+//     and a metrics registerer as its context.
 //
-//     - An observation Context can create an observation Operation which represents a
-//       section of code that can be invoked many times. An observation Operation is
-//       configured with state that applies to all invocation of the code.
+//   - An observation Context can create an observation Operation which represents a
+//     section of code that can be invoked many times. An observation Operation is
+//     configured with state that applies to all invocation of the code.
 //
-//     - An observation Operation can wrap a an invocation of a section of code by calling its
-//       With method. This prepares a trace and some state to be reconciled after the invocation
-//       has completed. The With method returns a function that, when deferred, will emit metrics,
-//       additional logs, and finalize the trace span.
+//   - An observation Operation can wrap a an invocation of a section of code by calling its
+//     With method. This prepares a trace and some state to be reconciled after the invocation
+//     has completed. The With method returns a function that, when deferred, will emit metrics,
+//     additional logs, and finalize the trace span.
 //
 // Sample usage:
 //
-//     observationContext := observation.NewContex(
-//         log15.Root(),
-//         &trace.Tracer{Tracer: opentracing.GlobalTracer()},
-//         prometheus.DefaultRegisterer,
-//     )
+//	observationContext := observation.NewContex(
+//	    log15.Root(),
+//	    &trace.Tracer{Tracer: opentracing.GlobalTracer()},
+//	    prometheus.DefaultRegisterer,
+//	)
 //
-//     metrics := metrics.NewOperationMetrics(
-//         observationContext.Registerer,
-//         "thing",
-//         metrics.WithLabels("op"),
-//     )
+//	metrics := metrics.NewOperationMetrics(
+//	    observationContext.Registerer,
+//	    "thing",
+//	    metrics.WithLabels("op"),
+//	)
 //
-//     operation := observationContext.Operation(observation.Op{
-//         Name:         "Thing.SomeOperation",
-//         MetricLabels: []string{"some_operation"},
-//         Metrics:      metrics,
-//     })
+//	operation := observationContext.Operation(observation.Op{
+//	    Name:         "Thing.SomeOperation",
+//	    MetricLabels: []string{"some_operation"},
+//	    Metrics:      metrics,
+//	})
 //
-//     function SomeOperation(ctx context.Context) (err error) {
-//         // logs and metrics may be available before or after the operation, so they
-//         // can be supplied either at the start of the operation, or after in the
-//         // defer of endObservation.
+//	function SomeOperation(ctx context.Context) (err error) {
+//	    // logs and metrics may be available before or after the operation, so they
+//	    // can be supplied either at the start of the operation, or after in the
+//	    // defer of endObservation.
 //
-//         ctx, endObservation := operation.With(ctx, &err, observation.Args{ /* logs and metrics */ })
-//         defer func() { endObservation(1, observation.Args{ /* additional logs and metrics */ }) }()
+//	    ctx, endObservation := operation.With(ctx, &err, observation.Args{ /* logs and metrics */ })
+//	    defer func() { endObservation(1, observation.Args{ /* additional logs and metrics */ }) }()
 //
-//         // ...
-//     }
+//	    // ...
+//	}
 //
 // Log fields and metric labels can be supplied at construction of an Operation, at invocation
 // of an operation (the With function), or after the invocation completes but before the observation
@@ -140,8 +140,8 @@ type Args struct {
 
 // LogFieldMap returns a string-to-interface map containing the contents of this Arg value's
 // log fields.
-func (args Args) LogFieldMap() map[string]interface{} {
-	fields := make(map[string]interface{}, len(args.LogFields))
+func (args Args) LogFieldMap() map[string]any {
+	fields := make(map[string]any, len(args.LogFields))
 	for _, field := range args.LogFields {
 		fields[field.Key()] = field.Value()
 	}
@@ -151,8 +151,8 @@ func (args Args) LogFieldMap() map[string]interface{} {
 
 // LogFieldPairs returns a slice of key, value, key, value, ... pairs containing the contents
 // of this Arg value's log fields.
-func (args Args) LogFieldPairs() []interface{} {
-	pairs := make([]interface{}, 0, len(args.LogFields)*2)
+func (args Args) LogFieldPairs() []any {
+	pairs := make([]any, 0, len(args.LogFields)*2)
 	for _, field := range args.LogFields {
 		pairs = append(pairs, field.Key(), field.Value())
 	}
@@ -217,7 +217,7 @@ func (op *Operation) emitErrorLogs(err *error, logFields []log.Field) {
 		return
 	}
 
-	var kvs []interface{}
+	var kvs []any
 	for _, field := range logFields {
 		kvs = append(kvs, field.Key(), field.Value())
 	}

--- a/internal/oobmigration/mock_test.go
+++ b/internal/oobmigration/mock_test.go
@@ -152,14 +152,14 @@ type MigratorDownFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c MigratorDownFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c MigratorDownFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c MigratorDownFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c MigratorDownFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // MigratorProgressFunc describes the behavior when the Progress method of
@@ -257,14 +257,14 @@ type MigratorProgressFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c MigratorProgressFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c MigratorProgressFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c MigratorProgressFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c MigratorProgressFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // MigratorUpFunc describes the behavior when the Up method of the parent
@@ -359,14 +359,14 @@ type MigratorUpFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c MigratorUpFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c MigratorUpFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c MigratorUpFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c MigratorUpFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // MockStoreIface is a mock implementation of the storeIface interface (from
@@ -530,14 +530,14 @@ type StoreIfaceAddErrorFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreIfaceAddErrorFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c StoreIfaceAddErrorFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreIfaceAddErrorFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c StoreIfaceAddErrorFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // StoreIfaceListFunc describes the behavior when the List method of the
@@ -635,14 +635,14 @@ type StoreIfaceListFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreIfaceListFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c StoreIfaceListFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreIfaceListFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c StoreIfaceListFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // StoreIfaceUpdateProgressFunc describes the behavior when the
@@ -744,12 +744,12 @@ type StoreIfaceUpdateProgressFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreIfaceUpdateProgressFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c StoreIfaceUpdateProgressFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreIfaceUpdateProgressFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c StoreIfaceUpdateProgressFuncCall) Results() []any {
+	return []any{c.Result0}
 }

--- a/internal/rcache/rcache.go
+++ b/internal/rcache/rcache.go
@@ -56,7 +56,7 @@ func (r *Cache) GetMulti(keys ...string) [][]byte {
 	if len(keys) == 0 {
 		return nil
 	}
-	rkeys := make([]interface{}, len(keys))
+	rkeys := make([]any, len(keys))
 	for i, key := range keys {
 		rkeys[i] = r.rkeyPrefix() + key
 	}
@@ -174,7 +174,7 @@ func (r *Cache) rkeyPrefix() string {
 // TB is a subset of testing.TB
 type TB interface {
 	Name() string
-	Skip(args ...interface{})
+	Skip(args ...any)
 	Helper()
 }
 

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -269,13 +269,12 @@ var configuredLimiter = func() *mutablelimiter.Limiter {
 // possible. We treat repos differently depending on which part of the
 // diff they are:
 //
-//
-//   Deleted    - remove from scheduler and queue.
-//   Added      - new repo, enqueue for asap clone.
-//   Modified   - likely new url or name. May also be a sign of new
-//                commits. Enqueue for asap clone (or fetch).
-//   Unmodified - we likely already have this cloned. Just rely on
-//                the scheduler and do not enqueue.
+//	Deleted    - remove from scheduler and queue.
+//	Added      - new repo, enqueue for asap clone.
+//	Modified   - likely new url or name. May also be a sign of new
+//	             commits. Enqueue for asap clone (or fetch).
+//	Unmodified - we likely already have this cloned. Just rely on
+//	             the scheduler and do not enqueue.
 func (s *updateScheduler) UpdateFromDiff(diff Diff) {
 	for _, r := range diff.Deleted {
 		s.remove(r)
@@ -377,7 +376,7 @@ func (s *updateScheduler) UpdateOnce(id api.RepoID, name api.RepoName) {
 }
 
 // DebugDump returns the state of the update scheduler for debugging.
-func (s *updateScheduler) DebugDump(ctx context.Context, db dbutil.DB) interface{} {
+func (s *updateScheduler) DebugDump(ctx context.Context, db dbutil.DB) any {
 	data := struct {
 		Name        string
 		UpdateQueue []*repoUpdate
@@ -627,7 +626,7 @@ func (q *updateQueue) Swap(i, j int) {
 	q.heap[j].Index = j
 }
 
-func (q *updateQueue) Push(x interface{}) {
+func (q *updateQueue) Push(x any) {
 	n := len(q.heap)
 	item := x.(*repoUpdate)
 	item.Index = n
@@ -636,7 +635,7 @@ func (q *updateQueue) Push(x interface{}) {
 	q.index[item.Repo.ID] = item
 }
 
-func (q *updateQueue) Pop() interface{} {
+func (q *updateQueue) Pop() any {
 	n := len(q.heap)
 	item := q.heap[n-1]
 	item.Index = -1 // for safety
@@ -871,7 +870,7 @@ func (s *schedule) Swap(i, j int) {
 	s.heap[j].Index = j
 }
 
-func (s *schedule) Push(x interface{}) {
+func (s *schedule) Push(x any) {
 	n := len(s.heap)
 	item := x.(*scheduledRepoUpdate)
 	item.Index = n
@@ -880,7 +879,7 @@ func (s *schedule) Push(x interface{}) {
 	schedKnownRepos.Inc()
 }
 
-func (s *schedule) Pop() interface{} {
+func (s *schedule) Pop() any {
 	n := len(s.heap)
 	item := s.heap[n-1]
 	item.Index = -1 // for safety

--- a/internal/repos/sources_test.go
+++ b/internal/repos/sources_test.go
@@ -771,7 +771,7 @@ func save(t testing.TB, rec *recorder.Recorder) {
 	}
 }
 
-func marshalJSON(t testing.TB, v interface{}) string {
+func marshalJSON(t testing.TB, v any) string {
 	t.Helper()
 
 	bs, err := json.Marshal(v)

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -556,7 +556,7 @@ func scanJobs(rows *sql.Rows) ([]SyncJob, error) {
 	for rows.Next() {
 		// required field for the sync worker, but
 		// the value is thrown out here
-		var executionLogs *[]interface{}
+		var executionLogs *[]any
 
 		var job SyncJob
 		if err := rows.Scan(
@@ -584,7 +584,7 @@ func scanJobs(rows *sql.Rows) ([]SyncJob, error) {
 	return jobs, nil
 }
 
-func metadataColumn(metadata interface{}) (msg json.RawMessage, err error) {
+func metadataColumn(metadata any) (msg json.RawMessage, err error) {
 	switch m := metadata.(type) {
 	case nil:
 		msg = json.RawMessage("{}")

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -293,7 +293,7 @@ func (c *Client) RepoExternalServices(ctx context.Context, id api.RepoID) ([]api
 	return res.ExternalServices, nil
 }
 
-func (c *Client) httpPost(ctx context.Context, method string, payload interface{}) (resp *http.Response, err error) {
+func (c *Client) httpPost(ctx context.Context, method string, payload any) (resp *http.Response, err error) {
 	reqBody, err := json.Marshal(payload)
 	if err != nil {
 		return nil, err

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -158,11 +158,11 @@ func (pq priorityQueue) Swap(i, j int) {
 	pq[i], pq[j] = pq[j], pq[i]
 }
 
-func (pq *priorityQueue) Push(x interface{}) {
+func (pq *priorityQueue) Push(x any) {
 	*pq = append(*pq, x.(*zoekt.SearchResult))
 }
 
-func (pq *priorityQueue) Pop() interface{} {
+func (pq *priorityQueue) Pop() any {
 	old := *pq
 	n := len(old)
 	item := old[n-1]

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/hexops/autogold"
 )
 
-func toJSON(node Node) interface{} {
+func toJSON(node Node) any {
 	switch n := node.(type) {
 	case Operator:
-		var jsons []interface{}
+		var jsons []any
 		for _, o := range n.Operands {
 			jsons = append(jsons, toJSON(o))
 		}
@@ -21,19 +21,19 @@ func toJSON(node Node) interface{} {
 		switch n.Kind {
 		case And:
 			return struct {
-				And []interface{} `json:"and"`
+				And []any `json:"and"`
 			}{
 				And: jsons,
 			}
 		case Or:
 			return struct {
-				Or []interface{} `json:"or"`
+				Or []any `json:"or"`
 			}{
 				Or: jsons,
 			}
 		case Concat:
 			return struct {
-				Concat []interface{} `json:"concat"`
+				Concat []any `json:"concat"`
 			}{
 				Concat: jsons,
 			}
@@ -64,7 +64,7 @@ func toJSON(node Node) interface{} {
 }
 
 func nodesToJSON(nodes []Node) string {
-	var jsons []interface{}
+	var jsons []any
 	for _, node := range nodes {
 		jsons = append(jsons, toJSON(node))
 	}

--- a/internal/search/query/value.go
+++ b/internal/search/query/value.go
@@ -23,7 +23,7 @@ type Value struct {
 }
 
 // Value returns the value as an interface{}.
-func (v *Value) Value() interface{} {
+func (v *Value) Value() any {
 	switch {
 	case v.String != nil:
 		return *v.String

--- a/internal/search/repos/repo_groups.go
+++ b/internal/search/repos/repo_groups.go
@@ -88,7 +88,7 @@ func ResolveRepoGroupsFromSettings(settings *schema.Settings) map[string][]RepoG
 			switch path := value.(type) {
 			case string:
 				repos = append(repos, RepoPath(path))
-			case map[string]interface{}:
+			case map[string]any:
 				if stringRegex, ok := path["regex"].(string); ok {
 					repos = append(repos, RepoRegexpPattern(stringRegex))
 				} else {

--- a/internal/search/streaming/filters.go
+++ b/internal/search/streaming/filters.go
@@ -136,11 +136,11 @@ func (h *filterHeap) Less(i, j int) bool {
 	return h.filterSlice[j].Less(h.filterSlice[i])
 }
 
-func (h *filterHeap) Push(x interface{}) {
+func (h *filterHeap) Push(x any) {
 	h.filterSlice = append(h.filterSlice, x.(*Filter))
 }
 
-func (h *filterHeap) Pop() interface{} {
+func (h *filterHeap) Pop() any {
 	old := h.filterSlice
 	n := len(old)
 	x := old[n-1]

--- a/internal/search/streaming/http/client_test.go
+++ b/internal/search/streaming/http/client_test.go
@@ -12,7 +12,7 @@ import (
 func TestDecoder(t *testing.T) {
 	type Event struct {
 		Name  string
-		Value interface{}
+		Value any
 	}
 
 	want := []Event{{

--- a/internal/search/streaming/http/writer.go
+++ b/internal/search/streaming/http/writer.go
@@ -46,7 +46,7 @@ func NewWriter(w http.ResponseWriter) (*Writer, error) {
 }
 
 // Event writes event with data json marshalled.
-func (e *Writer) Event(event string, data interface{}) error {
+func (e *Writer) Event(event string, data any) error {
 	encoded, err := json.Marshal(data)
 	if err != nil {
 		return err

--- a/internal/symbols/client.go
+++ b/internal/symbols/client.go
@@ -102,7 +102,7 @@ func (c *Client) Search(ctx context.Context, args search.SymbolsParameters) (res
 	return result, err
 }
 
-func (c *Client) httpPost(ctx context.Context, method string, key key, payload interface{}) (resp *http.Response, err error) {
+func (c *Client) httpPost(ctx context.Context, method string, key key, payload any) (resp *http.Response, err error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "symbols.Client.httpPost")
 	defer func() {
 		if err != nil {

--- a/internal/testutil/golden.go
+++ b/internal/testutil/golden.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func AssertGolden(t testing.TB, path string, update bool, want interface{}) {
+func AssertGolden(t testing.TB, path string, update bool, want any) {
 	t.Helper()
 
 	data := marshal(t, want)
@@ -33,7 +33,7 @@ func AssertGolden(t testing.TB, path string, update bool, want interface{}) {
 	}
 }
 
-func marshal(t testing.TB, v interface{}) []byte {
+func marshal(t testing.TB, v any) []byte {
 	t.Helper()
 
 	switch v2 := v.(type) {

--- a/internal/trace/traceutil.go
+++ b/internal/trace/traceutil.go
@@ -126,7 +126,7 @@ type Trace struct {
 // LazyPrintf evaluates its arguments with fmt.Sprintf each time the
 // /debug/requests page is rendered. Any memory referenced by a will be
 // pinned until the trace is finished and later discarded.
-func (t *Trace) LazyPrintf(format string, a ...interface{}) {
+func (t *Trace) LazyPrintf(format string, a ...any) {
 	t.span.LogFields(Printf("log", format, a...))
 	t.trace.LazyPrintf(format, a...)
 }
@@ -187,7 +187,7 @@ func (t tagsOpt) Apply(o *opentracing.StartSpanOptions) {
 		return
 	}
 	if o.Tags == nil {
-		o.Tags = make(map[string]interface{}, len(t.tags)+1)
+		o.Tags = make(map[string]any, len(t.tags)+1)
 	}
 	if t.title != "" {
 		o.Tags["title"] = t.title
@@ -200,7 +200,7 @@ func (t tagsOpt) Apply(o *opentracing.StartSpanOptions) {
 // Printf is an opentracing log.Field which is a LazyLogger. So the format
 // string will only be evaluated if the trace is collected. In the case of
 // net/trace, it will only be evaluated on page load.
-func Printf(key, f string, args ...interface{}) log.Field {
+func Printf(key, f string, args ...any) log.Field {
 	return log.Lazy(func(fv log.Encoder) {
 		fv.EmitString(key, fmt.Sprintf(f, args...))
 	})
@@ -285,7 +285,7 @@ func (e *encoder) EmitFloat32(key string, value float32) {
 func (e *encoder) EmitFloat64(key string, value float64) {
 	e.EmitString(key, strconv.FormatFloat(value, 'E', -1, 64))
 }
-func (e *encoder) EmitObject(key string, value interface{}) {
+func (e *encoder) EmitObject(key string, value any) {
 	e.EmitString(key, fmt.Sprintf("%+v", value))
 }
 

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -205,7 +205,7 @@ func (t *switchableTracer) StartSpan(operationName string, opts ...opentracing.S
 	return t.tracer.StartSpan(operationName, opts...)
 }
 
-func (t *switchableTracer) Inject(sm opentracing.SpanContext, format interface{}, carrier interface{}) error {
+func (t *switchableTracer) Inject(sm opentracing.SpanContext, format any, carrier any) error {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	if t.log {
@@ -214,7 +214,7 @@ func (t *switchableTracer) Inject(sm opentracing.SpanContext, format interface{}
 	return t.tracer.Inject(sm, format, carrier)
 }
 
-func (t *switchableTracer) Extract(format interface{}, carrier interface{}) (opentracing.SpanContext, error) {
+func (t *switchableTracer) Extract(format any, carrier any) (opentracing.SpanContext, error) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	if t.log {

--- a/internal/txemail/template.go
+++ b/internal/txemail/template.go
@@ -54,9 +54,9 @@ func ParseTemplate(input txtypes.Templates) (*txtypes.ParsedTemplates, error) {
 	return &txtypes.ParsedTemplates{Subj: st, Text: tt, Html: ht}, nil
 }
 
-func renderTemplate(t *txtypes.ParsedTemplates, data interface{}, m *email.Email) error {
+func renderTemplate(t *txtypes.ParsedTemplates, data any, m *email.Email) error {
 	render := func(tmpl interface {
-		Execute(io.Writer, interface{}) error
+		Execute(io.Writer, any) error
 	}) ([]byte, error) {
 		var buf bytes.Buffer
 		if err := tmpl.Execute(&buf, data); err != nil {
@@ -81,7 +81,7 @@ func renderTemplate(t *txtypes.ParsedTemplates, data interface{}, m *email.Email
 }
 
 var (
-	textFuncMap = map[string]interface{}{
+	textFuncMap = map[string]any{
 		// Removes HTML tags (which are valid Markdown) from the source, for display in a text-only
 		// setting.
 		"markdownToText": func(markdownSource string) string {
@@ -90,7 +90,7 @@ var (
 		},
 	}
 
-	htmlFuncMap = map[string]interface{}{
+	htmlFuncMap = map[string]any{
 		// Renders Markdown for display in an HTML email.
 		"markdownToSafeHTML": func(markdownSource string) htmltemplate.HTML {
 			unsafeHTML := gfm.Markdown([]byte(markdownSource))

--- a/internal/txemail/txemail.go
+++ b/internal/txemail/txemail.go
@@ -26,7 +26,7 @@ type Message struct {
 	References []string // optional "References" header list
 
 	Template txtypes.Templates // unparsed subject/body templates
-	Data     interface{}       // template data
+	Data     any               // template data
 }
 
 // render returns the rendered message contents without sending email.

--- a/internal/txemail/txtypes/types.go
+++ b/internal/txemail/txtypes/types.go
@@ -13,8 +13,8 @@ type Message struct {
 	MessageID  *string  // optional "Message-ID" header
 	References []string // optional "References" header list
 
-	Template Templates   // unparsed subject/body templates
-	Data     interface{} // template data
+	Template Templates // unparsed subject/body templates
+	Data     any       // template data
 }
 
 // Templates contains the text and HTML templates for an email.

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -163,7 +163,7 @@ type jsonStringField struct {
 	ptr  *string
 }
 
-func unredactField(old, new string, cfg interface{}, fields ...jsonStringField) (string, error) {
+func unredactField(old, new string, cfg any, fields ...jsonStringField) (string, error) {
 	// first we zero the fields on cfg, as they will contain data we don't need from the e.Configuration() call
 	// we just want an empty struct of the correct type for marshaling into
 	if err := zeroFields(cfg); err != nil {
@@ -203,7 +203,7 @@ func unredactField(old, new string, cfg interface{}, fields ...jsonStringField) 
 }
 
 // zeroFields zeroes the fields of a struct
-func zeroFields(s interface{}) error {
+func zeroFields(s any) error {
 	for _, f := range structs.Fields(s) {
 		if f.IsZero() {
 			continue
@@ -217,7 +217,7 @@ func zeroFields(s interface{}) error {
 }
 
 // config may contain comments, normalize with jsonc before unmarshaling with jsoniter
-func unmarshalConfig(buf string, v interface{}) error {
+func unmarshalConfig(buf string, v any) error {
 	normalized, err := jsonc.Parse(buf)
 	if err != nil {
 		return err

--- a/internal/types/secret_test.go
+++ b/internal/types/secret_test.go
@@ -53,9 +53,9 @@ func TestRoundTripRedactExternalServiceConfig(t *testing.T) {
 	}
 	var tc = []struct {
 		kind        string
-		config      interface{} // the config for the service kind
-		editField   *string     // a pointer to a field on the config we can edit to simulate the user using the API
-		secretField *string     // a pointer to the field we expect to be obfuscated
+		config      any     // the config for the service kind
+		editField   *string // a pointer to a field on the config we can edit to simulate the user using the API
+		secretField *string // a pointer to the field we expect to be obfuscated
 	}{
 		{
 			kind:        extsvc.KindGitHub,

--- a/internal/types/testing.go
+++ b/internal/types/testing.go
@@ -218,7 +218,7 @@ var Opt = struct {
 	RepoModifiedAt            func(time.Time) func(*Repo)
 	RepoDeletedAt             func(time.Time) func(*Repo)
 	RepoSources               func(...string) func(*Repo)
-	RepoMetadata              func(interface{}) func(*Repo)
+	RepoMetadata              func(any) func(*Repo)
 	RepoExternalID            func(string) func(*Repo)
 }{
 	ExternalServiceID: func(n int64) func(*ExternalService) {
@@ -276,7 +276,7 @@ var Opt = struct {
 			}
 		}
 	},
-	RepoMetadata: func(md interface{}) func(*Repo) {
+	RepoMetadata: func(md any) func(*Repo) {
 		return func(r *Repo) {
 			r.Metadata = md
 		}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -62,7 +62,7 @@ type Repo struct {
 	// The key is a URN created by extsvc.URN
 	Sources map[string]*SourceInfo
 	// Metadata contains the raw source code host JSON metadata.
-	Metadata interface{}
+	Metadata any
 	// Blocked contains the reason this repository was blocked and the timestamp of when it happened.
 	Blocked *RepoBlock `json:",omitempty"`
 }
@@ -506,7 +506,7 @@ func (e *ExternalService) Update(n *ExternalService) (modified bool) {
 }
 
 // Configuration returns the external service config.
-func (e *ExternalService) Configuration() (cfg interface{}, _ error) {
+func (e *ExternalService) Configuration() (cfg any, _ error) {
 	return extsvc.ParseConfig(e.Kind, e.Config)
 }
 

--- a/internal/vcs/git/main_test.go
+++ b/internal/vcs/git/main_test.go
@@ -79,7 +79,7 @@ func init() {
 	}
 }
 
-func AsJSON(v interface{}) string {
+func AsJSON(v any) string {
 	b, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		panic(err)

--- a/internal/vcs/git/tree.go
+++ b/internal/vcs/git/tree.go
@@ -275,7 +275,7 @@ func lsTreeUncached(ctx context.Context, repo api.RepoName, commit api.CommitID,
 			}
 		}
 
-		var sys interface{}
+		var sys any
 		modeVal, err := strconv.ParseInt(info[0], 8, 32)
 		if err != nil {
 			return nil, err

--- a/internal/vcs/util/fileinfo.go
+++ b/internal/vcs/util/fileinfo.go
@@ -13,7 +13,7 @@ type FileInfo struct {
 	Mode_    os.FileMode
 	Size_    int64
 	ModTime_ time.Time
-	Sys_     interface{}
+	Sys_     any
 }
 
 func (fi *FileInfo) Name() string       { return fi.Name_ }
@@ -21,7 +21,7 @@ func (fi *FileInfo) Size() int64        { return fi.Size_ }
 func (fi *FileInfo) Mode() os.FileMode  { return fi.Mode_ }
 func (fi *FileInfo) ModTime() time.Time { return fi.ModTime_ }
 func (fi *FileInfo) IsDir() bool        { return fi.Mode().IsDir() }
-func (fi *FileInfo) Sys() interface{}   { return fi.Sys_ }
+func (fi *FileInfo) Sys() any           { return fi.Sys_ }
 
 // SortFileInfosByName sorts fis by name, alphabetically.
 func SortFileInfosByName(fis []fs.FileInfo) {

--- a/internal/workerutil/dbworker/store/helpers_test.go
+++ b/internal/workerutil/dbworker/store/helpers_test.go
@@ -157,7 +157,7 @@ func defaultTestStoreOptions(clock glock.Clock) Options {
 	}
 }
 
-func assertDequeueRecordResult(t *testing.T, expectedID int, record interface{}, ok bool, err error) {
+func assertDequeueRecordResult(t *testing.T, expectedID int, record any, ok bool, err error) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -173,13 +173,13 @@ func assertDequeueRecordResult(t *testing.T, expectedID int, record interface{},
 	}
 }
 
-func assertDequeueRecordResultLogCount(t *testing.T, expectedLogCount int, record interface{}) {
+func assertDequeueRecordResultLogCount(t *testing.T, expectedLogCount int, record any) {
 	if val := len(record.(TestRecord).ExecutionLogs); val != expectedLogCount {
 		t.Errorf("unexpected count of logs. want=%d have=%d", expectedLogCount, val)
 	}
 }
 
-func assertDequeueRecordViewResult(t *testing.T, expectedID, expectedNewField int, record interface{}, ok bool, err error) {
+func assertDequeueRecordViewResult(t *testing.T, expectedID, expectedNewField int, record any, ok bool, err error) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -198,7 +198,7 @@ func assertDequeueRecordViewResult(t *testing.T, expectedID, expectedNewField in
 	}
 }
 
-func assertDequeueRecordRetryResult(t *testing.T, expectedID, record interface{}, ok bool, err error) {
+func assertDequeueRecordRetryResult(t *testing.T, expectedID, record any, ok bool, err error) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/internal/workerutil/dbworker/store/mocks/mock_store.go
+++ b/internal/workerutil/dbworker/store/mocks/mock_store.go
@@ -260,14 +260,14 @@ type StoreAddExecutionLogEntryFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreAddExecutionLogEntryFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c StoreAddExecutionLogEntryFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreAddExecutionLogEntryFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c StoreAddExecutionLogEntryFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // StoreDequeueFunc describes the behavior when the Dequeue method of the
@@ -374,14 +374,14 @@ type StoreDequeueFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreDequeueFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c StoreDequeueFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreDequeueFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c StoreDequeueFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // StoreHandleFunc describes the behavior when the Handle method of the
@@ -473,14 +473,14 @@ type StoreHandleFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreHandleFuncCall) Args() []interface{} {
-	return []interface{}{}
+func (c StoreHandleFuncCall) Args() []any {
+	return []any{}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreHandleFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c StoreHandleFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // StoreHeartbeatFunc describes the behavior when the Heartbeat method of
@@ -584,14 +584,14 @@ type StoreHeartbeatFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreHeartbeatFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c StoreHeartbeatFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreHeartbeatFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c StoreHeartbeatFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // StoreMarkCompleteFunc describes the behavior when the MarkComplete method
@@ -695,14 +695,14 @@ type StoreMarkCompleteFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreMarkCompleteFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c StoreMarkCompleteFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreMarkCompleteFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c StoreMarkCompleteFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // StoreMarkErroredFunc describes the behavior when the MarkErrored method
@@ -809,14 +809,14 @@ type StoreMarkErroredFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreMarkErroredFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c StoreMarkErroredFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreMarkErroredFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c StoreMarkErroredFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // StoreMarkFailedFunc describes the behavior when the MarkFailed method of
@@ -923,14 +923,14 @@ type StoreMarkFailedFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreMarkFailedFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c StoreMarkFailedFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreMarkFailedFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c StoreMarkFailedFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // StoreQueuedCountFunc describes the behavior when the QueuedCount method
@@ -1031,14 +1031,14 @@ type StoreQueuedCountFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreQueuedCountFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c StoreQueuedCountFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreQueuedCountFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c StoreQueuedCountFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // StoreRequeueFunc describes the behavior when the Requeue method of the
@@ -1139,14 +1139,14 @@ type StoreRequeueFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreRequeueFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c StoreRequeueFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreRequeueFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c StoreRequeueFuncCall) Results() []any {
+	return []any{c.Result0}
 }
 
 // StoreResetStalledFunc describes the behavior when the ResetStalled method
@@ -1247,14 +1247,14 @@ type StoreResetStalledFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreResetStalledFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c StoreResetStalledFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreResetStalledFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c StoreResetStalledFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // StoreUpdateExecutionLogEntryFunc describes the behavior when the
@@ -1363,12 +1363,12 @@ type StoreUpdateExecutionLogEntryFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreUpdateExecutionLogEntryFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+func (c StoreUpdateExecutionLogEntryFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreUpdateExecutionLogEntryFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c StoreUpdateExecutionLogEntryFuncCall) Results() []any {
+	return []any{c.Result0}
 }

--- a/internal/workerutil/dbworker/store/store.go
+++ b/internal/workerutil/dbworker/store/store.go
@@ -24,7 +24,7 @@ type HeartbeatOptions struct {
 	WorkerHostname string
 }
 
-func (o *HeartbeatOptions) ToSQLConds(formatQuery func(query string, args ...interface{}) *sqlf.Query) []*sqlf.Query {
+func (o *HeartbeatOptions) ToSQLConds(formatQuery func(query string, args ...any) *sqlf.Query) []*sqlf.Query {
 	conds := []*sqlf.Query{}
 	if o.WorkerHostname != "" {
 		conds = append(conds, formatQuery("{worker_hostname} = %s", o.WorkerHostname))
@@ -39,7 +39,7 @@ type ExecutionLogEntryOptions struct {
 	State string
 }
 
-func (o *ExecutionLogEntryOptions) ToSQLConds(formatQuery func(query string, args ...interface{}) *sqlf.Query) []*sqlf.Query {
+func (o *ExecutionLogEntryOptions) ToSQLConds(formatQuery func(query string, args ...any) *sqlf.Query) []*sqlf.Query {
 	conds := []*sqlf.Query{}
 	if o.WorkerHostname != "" {
 		conds = append(conds, formatQuery("{worker_hostname} = %s", o.WorkerHostname))
@@ -55,7 +55,7 @@ type MarkFinalOptions struct {
 	WorkerHostname string
 }
 
-func (o *MarkFinalOptions) ToSQLConds(formatQuery func(query string, args ...interface{}) *sqlf.Query) []*sqlf.Query {
+func (o *MarkFinalOptions) ToSQLConds(formatQuery func(query string, args ...any) *sqlf.Query) []*sqlf.Query {
 	conds := []*sqlf.Query{}
 	if o.WorkerHostname != "" {
 		conds = append(conds, formatQuery("{worker_hostname} = %s", o.WorkerHostname))
@@ -122,7 +122,7 @@ type Store interface {
 
 type ExecutionLogEntry workerutil.ExecutionLogEntry
 
-func (e *ExecutionLogEntry) Scan(value interface{}) error {
+func (e *ExecutionLogEntry) Scan(value any) error {
 	b, ok := value.([]byte)
 	if !ok {
 		return errors.Errorf("value is not []byte: %T", value)
@@ -760,7 +760,7 @@ WHERE {id} IN (SELECT {id} FROM stalled)
 RETURNING {id}
 `
 
-func (s *store) formatQuery(query string, args ...interface{}) *sqlf.Query {
+func (s *store) formatQuery(query string, args ...any) *sqlf.Query {
 	return sqlf.Sprintf(s.columnReplacer.Replace(query), args...)
 }
 

--- a/internal/workerutil/dbworker/store_shim.go
+++ b/internal/workerutil/dbworker/store_shim.go
@@ -27,7 +27,7 @@ func newStoreShim(store store.Store) workerutil.Store {
 }
 
 // QueuedCount calls into the inner store.
-func (s *storeShim) QueuedCount(ctx context.Context, extraArguments interface{}) (int, error) {
+func (s *storeShim) QueuedCount(ctx context.Context, extraArguments any) (int, error) {
 	conditions, err := convertArguments(extraArguments)
 	if err != nil {
 		return 0, err
@@ -37,7 +37,7 @@ func (s *storeShim) QueuedCount(ctx context.Context, extraArguments interface{})
 }
 
 // Dequeue calls into the inner store.
-func (s *storeShim) Dequeue(ctx context.Context, workerHostname string, extraArguments interface{}) (workerutil.Record, bool, error) {
+func (s *storeShim) Dequeue(ctx context.Context, workerHostname string, extraArguments any) (workerutil.Record, bool, error) {
 	conditions, err := convertArguments(extraArguments)
 	if err != nil {
 		return nil, false, err
@@ -74,7 +74,7 @@ func (s *storeShim) MarkErrored(ctx context.Context, id int, errorMessage string
 var ErrNotConditions = errors.New("expected slice of *sqlf.Query values")
 
 // convertArguments converts the given interface value into a slice of *sqlf.Query values.
-func convertArguments(v interface{}) ([]*sqlf.Query, error) {
+func convertArguments(v any) ([]*sqlf.Query, error) {
 	if v == nil {
 		return nil, nil
 	}

--- a/internal/workerutil/handler.go
+++ b/internal/workerutil/handler.go
@@ -24,7 +24,7 @@ type WithPreDequeue interface {
 	// If this method returns false, then the current worker iteration is skipped and the next iteration
 	// will begin after waiting for the configured polling interval. Any value returned by this method
 	// will be used as additional parameters to the store's Dequeue method.
-	PreDequeue(ctx context.Context) (dequeueable bool, extraDequeueArguments interface{}, err error)
+	PreDequeue(ctx context.Context) (dequeueable bool, extraDequeueArguments any, err error)
 }
 
 // WithHooks is an extension of the Handler interface.

--- a/internal/workerutil/mock_handler_test.go
+++ b/internal/workerutil/mock_handler_test.go
@@ -133,12 +133,12 @@ type HandlerHandleFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c HandlerHandleFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c HandlerHandleFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c HandlerHandleFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c HandlerHandleFuncCall) Results() []any {
+	return []any{c.Result0}
 }

--- a/internal/workerutil/mock_store_test.go
+++ b/internal/workerutil/mock_store_test.go
@@ -47,7 +47,7 @@ func NewMockStore() *MockStore {
 			},
 		},
 		DequeueFunc: &StoreDequeueFunc{
-			defaultHook: func(context.Context, string, interface{}) (Record, bool, error) {
+			defaultHook: func(context.Context, string, any) (Record, bool, error) {
 				return nil, false, nil
 			},
 		},
@@ -72,7 +72,7 @@ func NewMockStore() *MockStore {
 			},
 		},
 		QueuedCountFunc: &StoreQueuedCountFunc{
-			defaultHook: func(context.Context, interface{}) (int, error) {
+			defaultHook: func(context.Context, any) (int, error) {
 				return 0, nil
 			},
 		},
@@ -217,28 +217,28 @@ type StoreAddExecutionLogEntryFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreAddExecutionLogEntryFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c StoreAddExecutionLogEntryFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreAddExecutionLogEntryFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c StoreAddExecutionLogEntryFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // StoreDequeueFunc describes the behavior when the Dequeue method of the
 // parent MockStore instance is invoked.
 type StoreDequeueFunc struct {
-	defaultHook func(context.Context, string, interface{}) (Record, bool, error)
-	hooks       []func(context.Context, string, interface{}) (Record, bool, error)
+	defaultHook func(context.Context, string, any) (Record, bool, error)
+	hooks       []func(context.Context, string, any) (Record, bool, error)
 	history     []StoreDequeueFuncCall
 	mutex       sync.Mutex
 }
 
 // Dequeue delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockStore) Dequeue(v0 context.Context, v1 string, v2 interface{}) (Record, bool, error) {
+func (m *MockStore) Dequeue(v0 context.Context, v1 string, v2 any) (Record, bool, error) {
 	r0, r1, r2 := m.DequeueFunc.nextHook()(v0, v1, v2)
 	m.DequeueFunc.appendCall(StoreDequeueFuncCall{v0, v1, v2, r0, r1, r2})
 	return r0, r1, r2
@@ -246,7 +246,7 @@ func (m *MockStore) Dequeue(v0 context.Context, v1 string, v2 interface{}) (Reco
 
 // SetDefaultHook sets function that is called when the Dequeue method of
 // the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreDequeueFunc) SetDefaultHook(hook func(context.Context, string, interface{}) (Record, bool, error)) {
+func (f *StoreDequeueFunc) SetDefaultHook(hook func(context.Context, string, any) (Record, bool, error)) {
 	f.defaultHook = hook
 }
 
@@ -254,7 +254,7 @@ func (f *StoreDequeueFunc) SetDefaultHook(hook func(context.Context, string, int
 // Dequeue method of the parent MockStore instance invokes the hook at the
 // front of the queue and discards it. After the queue is empty, the default
 // hook function is invoked for any future action.
-func (f *StoreDequeueFunc) PushHook(hook func(context.Context, string, interface{}) (Record, bool, error)) {
+func (f *StoreDequeueFunc) PushHook(hook func(context.Context, string, any) (Record, bool, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -263,7 +263,7 @@ func (f *StoreDequeueFunc) PushHook(hook func(context.Context, string, interface
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *StoreDequeueFunc) SetDefaultReturn(r0 Record, r1 bool, r2 error) {
-	f.SetDefaultHook(func(context.Context, string, interface{}) (Record, bool, error) {
+	f.SetDefaultHook(func(context.Context, string, any) (Record, bool, error) {
 		return r0, r1, r2
 	})
 }
@@ -271,12 +271,12 @@ func (f *StoreDequeueFunc) SetDefaultReturn(r0 Record, r1 bool, r2 error) {
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *StoreDequeueFunc) PushReturn(r0 Record, r1 bool, r2 error) {
-	f.PushHook(func(context.Context, string, interface{}) (Record, bool, error) {
+	f.PushHook(func(context.Context, string, any) (Record, bool, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *StoreDequeueFunc) nextHook() func(context.Context, string, interface{}) (Record, bool, error) {
+func (f *StoreDequeueFunc) nextHook() func(context.Context, string, any) (Record, bool, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -317,7 +317,7 @@ type StoreDequeueFuncCall struct {
 	Arg1 string
 	// Arg2 is the value of the 3rd argument passed to this method
 	// invocation.
-	Arg2 interface{}
+	Arg2 any
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 Record
@@ -331,14 +331,14 @@ type StoreDequeueFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreDequeueFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c StoreDequeueFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreDequeueFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c StoreDequeueFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }
 
 // StoreHeartbeatFunc describes the behavior when the Heartbeat method of
@@ -439,14 +439,14 @@ type StoreHeartbeatFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreHeartbeatFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c StoreHeartbeatFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreHeartbeatFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c StoreHeartbeatFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // StoreMarkCompleteFunc describes the behavior when the MarkComplete method
@@ -547,14 +547,14 @@ type StoreMarkCompleteFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreMarkCompleteFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c StoreMarkCompleteFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreMarkCompleteFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c StoreMarkCompleteFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // StoreMarkErroredFunc describes the behavior when the MarkErrored method
@@ -658,14 +658,14 @@ type StoreMarkErroredFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreMarkErroredFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c StoreMarkErroredFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreMarkErroredFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c StoreMarkErroredFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // StoreMarkFailedFunc describes the behavior when the MarkFailed method of
@@ -769,28 +769,28 @@ type StoreMarkFailedFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreMarkFailedFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+func (c StoreMarkFailedFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreMarkFailedFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c StoreMarkFailedFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // StoreQueuedCountFunc describes the behavior when the QueuedCount method
 // of the parent MockStore instance is invoked.
 type StoreQueuedCountFunc struct {
-	defaultHook func(context.Context, interface{}) (int, error)
-	hooks       []func(context.Context, interface{}) (int, error)
+	defaultHook func(context.Context, any) (int, error)
+	hooks       []func(context.Context, any) (int, error)
 	history     []StoreQueuedCountFuncCall
 	mutex       sync.Mutex
 }
 
 // QueuedCount delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockStore) QueuedCount(v0 context.Context, v1 interface{}) (int, error) {
+func (m *MockStore) QueuedCount(v0 context.Context, v1 any) (int, error) {
 	r0, r1 := m.QueuedCountFunc.nextHook()(v0, v1)
 	m.QueuedCountFunc.appendCall(StoreQueuedCountFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -798,7 +798,7 @@ func (m *MockStore) QueuedCount(v0 context.Context, v1 interface{}) (int, error)
 
 // SetDefaultHook sets function that is called when the QueuedCount method
 // of the parent MockStore instance is invoked and the hook queue is empty.
-func (f *StoreQueuedCountFunc) SetDefaultHook(hook func(context.Context, interface{}) (int, error)) {
+func (f *StoreQueuedCountFunc) SetDefaultHook(hook func(context.Context, any) (int, error)) {
 	f.defaultHook = hook
 }
 
@@ -806,7 +806,7 @@ func (f *StoreQueuedCountFunc) SetDefaultHook(hook func(context.Context, interfa
 // QueuedCount method of the parent MockStore instance invokes the hook at
 // the front of the queue and discards it. After the queue is empty, the
 // default hook function is invoked for any future action.
-func (f *StoreQueuedCountFunc) PushHook(hook func(context.Context, interface{}) (int, error)) {
+func (f *StoreQueuedCountFunc) PushHook(hook func(context.Context, any) (int, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -815,7 +815,7 @@ func (f *StoreQueuedCountFunc) PushHook(hook func(context.Context, interface{}) 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *StoreQueuedCountFunc) SetDefaultReturn(r0 int, r1 error) {
-	f.SetDefaultHook(func(context.Context, interface{}) (int, error) {
+	f.SetDefaultHook(func(context.Context, any) (int, error) {
 		return r0, r1
 	})
 }
@@ -823,12 +823,12 @@ func (f *StoreQueuedCountFunc) SetDefaultReturn(r0 int, r1 error) {
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *StoreQueuedCountFunc) PushReturn(r0 int, r1 error) {
-	f.PushHook(func(context.Context, interface{}) (int, error) {
+	f.PushHook(func(context.Context, any) (int, error) {
 		return r0, r1
 	})
 }
 
-func (f *StoreQueuedCountFunc) nextHook() func(context.Context, interface{}) (int, error) {
+func (f *StoreQueuedCountFunc) nextHook() func(context.Context, any) (int, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -866,7 +866,7 @@ type StoreQueuedCountFuncCall struct {
 	Arg0 context.Context
 	// Arg1 is the value of the 2nd argument passed to this method
 	// invocation.
-	Arg1 interface{}
+	Arg1 any
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 int
@@ -877,14 +877,14 @@ type StoreQueuedCountFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreQueuedCountFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c StoreQueuedCountFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreQueuedCountFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c StoreQueuedCountFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // StoreUpdateExecutionLogEntryFunc describes the behavior when the
@@ -990,12 +990,12 @@ type StoreUpdateExecutionLogEntryFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c StoreUpdateExecutionLogEntryFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
+func (c StoreUpdateExecutionLogEntryFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1, c.Arg2, c.Arg3}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c StoreUpdateExecutionLogEntryFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0}
+func (c StoreUpdateExecutionLogEntryFuncCall) Results() []any {
+	return []any{c.Result0}
 }

--- a/internal/workerutil/mock_with_hooks_test.go
+++ b/internal/workerutil/mock_with_hooks_test.go
@@ -141,14 +141,14 @@ type WithHooksPostHandleFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c WithHooksPostHandleFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c WithHooksPostHandleFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c WithHooksPostHandleFuncCall) Results() []interface{} {
-	return []interface{}{}
+func (c WithHooksPostHandleFuncCall) Results() []any {
+	return []any{}
 }
 
 // WithHooksPreHandleFunc describes the behavior when the PreHandle method
@@ -243,12 +243,12 @@ type WithHooksPreHandleFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c WithHooksPreHandleFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c WithHooksPreHandleFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c WithHooksPreHandleFuncCall) Results() []interface{} {
-	return []interface{}{}
+func (c WithHooksPreHandleFuncCall) Results() []any {
+	return []any{}
 }

--- a/internal/workerutil/mock_with_predequeue_test.go
+++ b/internal/workerutil/mock_with_predequeue_test.go
@@ -22,7 +22,7 @@ type MockWithPreDequeue struct {
 func NewMockWithPreDequeue() *MockWithPreDequeue {
 	return &MockWithPreDequeue{
 		PreDequeueFunc: &WithPreDequeuePreDequeueFunc{
-			defaultHook: func(context.Context) (bool, interface{}, error) {
+			defaultHook: func(context.Context) (bool, any, error) {
 				return false, nil, nil
 			},
 		},
@@ -43,15 +43,15 @@ func NewMockWithPreDequeueFrom(i WithPreDequeue) *MockWithPreDequeue {
 // WithPreDequeuePreDequeueFunc describes the behavior when the PreDequeue
 // method of the parent MockWithPreDequeue instance is invoked.
 type WithPreDequeuePreDequeueFunc struct {
-	defaultHook func(context.Context) (bool, interface{}, error)
-	hooks       []func(context.Context) (bool, interface{}, error)
+	defaultHook func(context.Context) (bool, any, error)
+	hooks       []func(context.Context) (bool, any, error)
 	history     []WithPreDequeuePreDequeueFuncCall
 	mutex       sync.Mutex
 }
 
 // PreDequeue delegates to the next hook function in the queue and stores
 // the parameter and result values of this invocation.
-func (m *MockWithPreDequeue) PreDequeue(v0 context.Context) (bool, interface{}, error) {
+func (m *MockWithPreDequeue) PreDequeue(v0 context.Context) (bool, any, error) {
 	r0, r1, r2 := m.PreDequeueFunc.nextHook()(v0)
 	m.PreDequeueFunc.appendCall(WithPreDequeuePreDequeueFuncCall{v0, r0, r1, r2})
 	return r0, r1, r2
@@ -60,7 +60,7 @@ func (m *MockWithPreDequeue) PreDequeue(v0 context.Context) (bool, interface{}, 
 // SetDefaultHook sets function that is called when the PreDequeue method of
 // the parent MockWithPreDequeue instance is invoked and the hook queue is
 // empty.
-func (f *WithPreDequeuePreDequeueFunc) SetDefaultHook(hook func(context.Context) (bool, interface{}, error)) {
+func (f *WithPreDequeuePreDequeueFunc) SetDefaultHook(hook func(context.Context) (bool, any, error)) {
 	f.defaultHook = hook
 }
 
@@ -68,7 +68,7 @@ func (f *WithPreDequeuePreDequeueFunc) SetDefaultHook(hook func(context.Context)
 // PreDequeue method of the parent MockWithPreDequeue instance invokes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *WithPreDequeuePreDequeueFunc) PushHook(hook func(context.Context) (bool, interface{}, error)) {
+func (f *WithPreDequeuePreDequeueFunc) PushHook(hook func(context.Context) (bool, any, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -76,21 +76,21 @@ func (f *WithPreDequeuePreDequeueFunc) PushHook(hook func(context.Context) (bool
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *WithPreDequeuePreDequeueFunc) SetDefaultReturn(r0 bool, r1 interface{}, r2 error) {
-	f.SetDefaultHook(func(context.Context) (bool, interface{}, error) {
+func (f *WithPreDequeuePreDequeueFunc) SetDefaultReturn(r0 bool, r1 any, r2 error) {
+	f.SetDefaultHook(func(context.Context) (bool, any, error) {
 		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *WithPreDequeuePreDequeueFunc) PushReturn(r0 bool, r1 interface{}, r2 error) {
-	f.PushHook(func(context.Context) (bool, interface{}, error) {
+func (f *WithPreDequeuePreDequeueFunc) PushReturn(r0 bool, r1 any, r2 error) {
+	f.PushHook(func(context.Context) (bool, any, error) {
 		return r0, r1, r2
 	})
 }
 
-func (f *WithPreDequeuePreDequeueFunc) nextHook() func(context.Context) (bool, interface{}, error) {
+func (f *WithPreDequeuePreDequeueFunc) nextHook() func(context.Context) (bool, any, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -131,7 +131,7 @@ type WithPreDequeuePreDequeueFuncCall struct {
 	Result0 bool
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
-	Result1 interface{}
+	Result1 any
 	// Result2 is the value of the 3rd result returned from this method
 	// invocation.
 	Result2 error
@@ -139,12 +139,12 @@ type WithPreDequeuePreDequeueFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c WithPreDequeuePreDequeueFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0}
+func (c WithPreDequeuePreDequeueFuncCall) Args() []any {
+	return []any{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c WithPreDequeuePreDequeueFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1, c.Result2}
+func (c WithPreDequeuePreDequeueFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1, c.Result2}
 }

--- a/internal/workerutil/store.go
+++ b/internal/workerutil/store.go
@@ -15,12 +15,12 @@ type Record interface {
 type Store interface {
 	// QueuedCount returns the number of records in the queued state. Any extra arguments supplied will be used in
 	// accordance with the concrete persistence layer (e.g. additional SQL conditions for a database layer).
-	QueuedCount(ctx context.Context, extraArguments interface{}) (int, error)
+	QueuedCount(ctx context.Context, extraArguments any) (int, error)
 
 	// Dequeue selects a record for processing. Any extra arguments supplied will be used in accordance with the
 	// concrete persistence layer (e.g. additional SQL conditions for a database layer). This method returns a boolean
 	// flag indicating the existence of a processable record.
-	Dequeue(ctx context.Context, workerHostname string, extraArguments interface{}) (Record, bool, error)
+	Dequeue(ctx context.Context, workerHostname string, extraArguments any) (Record, bool, error)
 
 	// Heartbeat updates last_heartbeat_at of all the given jobs, when they're processing. All IDs of records that were
 	// touched are returned.

--- a/internal/workerutil/worker.go
+++ b/internal/workerutil/worker.go
@@ -275,7 +275,7 @@ func (w *Worker) handle(ctx context.Context, record Record) (err error) {
 }
 
 // preDequeueHook invokes the handler's pre-dequeue hook if it exists.
-func (w *Worker) preDequeueHook() (dequeueable bool, extraDequeueArguments interface{}, err error) {
+func (w *Worker) preDequeueHook() (dequeueable bool, extraDequeueArguments any, err error) {
 	if o, ok := w.handler.(WithPreDequeue); ok {
 		return o.PreDequeue(w.ctx)
 	}

--- a/lib/batches/published.go
+++ b/lib/batches/published.go
@@ -9,7 +9,7 @@ import (
 // PublishedValue is a wrapper type that supports the quadruple `true`, `false`,
 // `"draft"`, `nil`.
 type PublishedValue struct {
-	Val interface{}
+	Val any
 }
 
 // True is true if the enclosed value is a bool being true.
@@ -47,7 +47,7 @@ func (p *PublishedValue) Valid() bool {
 }
 
 // Value returns the underlying value stored in this wrapper.
-func (p *PublishedValue) Value() interface{} {
+func (p *PublishedValue) Value() any {
 	return p.Val
 }
 
@@ -76,7 +76,7 @@ func (p *PublishedValue) UnmarshalJSON(b []byte) error {
 }
 
 // UnmarshalYAML unmarshalls a YAML value into a Publish.
-func (p *PublishedValue) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (p *PublishedValue) UnmarshalYAML(unmarshal func(any) error) error {
 	if err := unmarshal(&p.Val); err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ func (p *PublishedValue) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	return nil
 }
 
-func (p *PublishedValue) UnmarshalGraphQL(input interface{}) error {
+func (p *PublishedValue) UnmarshalGraphQL(input any) error {
 	p.Val = input
 	if !p.Valid() {
 		return errors.Errorf("invalid PublishedValue: %v", input)

--- a/lib/batches/published_test.go
+++ b/lib/batches/published_test.go
@@ -10,7 +10,7 @@ import (
 func TestPublishedValue(t *testing.T) {
 	tests := []struct {
 		name    string
-		val     interface{}
+		val     any
 		True    bool
 		False   bool
 		Draft   bool
@@ -46,7 +46,7 @@ func TestPublishedValue(t *testing.T) {
 	t.Run("JSON marshal", func(t *testing.T) {
 		tests := []struct {
 			name     string
-			val      interface{}
+			val      any
 			expected string
 		}{
 			{name: "true", val: true, expected: "true"},
@@ -71,7 +71,7 @@ func TestPublishedValue(t *testing.T) {
 		tests := []struct {
 			name     string
 			val      string
-			expected interface{}
+			expected any
 		}{
 			{name: "true", val: "true", expected: true},
 			{name: "false", val: "false", expected: false},
@@ -94,7 +94,7 @@ func TestPublishedValue(t *testing.T) {
 		tests := []struct {
 			name     string
 			val      string
-			expected interface{}
+			expected any
 		}{
 			{name: "true", val: "true", expected: true},
 			{name: "true", val: "yes", expected: true},

--- a/lib/codeintel/autoindex/config/json.go
+++ b/lib/codeintel/autoindex/config/json.go
@@ -53,7 +53,7 @@ func UnmarshalJSON(data []byte) (IndexConfiguration, error) {
 
 // jsonUnmarshal unmarshals the JSON using a fault-tolerant parser that allows comments
 // and trailing commas. If any unrecoverable faults are found, an error is returned.
-func jsonUnmarshal(text string, v interface{}) error {
+func jsonUnmarshal(text string, v any) error {
 	data, errs := jsonx.Parse(text, jsonx.ParseOptions{Comments: true, TrailingCommas: true})
 	if len(errs) > 0 {
 		return errors.Errorf("failed to parse JSON: %v", errs)

--- a/lib/codeintel/autoindex/config/json_test.go
+++ b/lib/codeintel/autoindex/config/json_test.go
@@ -87,12 +87,12 @@ func TestJsonUnmarshal(t *testing.T) {
 		"hello": "world",
 	}`
 
-	var actual interface{}
+	var actual any
 	if err := jsonUnmarshal(input, &actual); err != nil {
 		t.Fatalf("unexpected error unmarshalling payload: %s", err)
 	}
 
-	if diff := cmp.Diff(map[string]interface{}{"hello": "world"}, actual); diff != "" {
+	if diff := cmp.Diff(map[string]any{"hello": "world"}, actual); diff != "" {
 		t.Errorf("unexpected configuration (-want +got):\n%s", diff)
 	}
 }

--- a/lib/codeintel/autoindex/inference/mock_gitclient_test.go
+++ b/lib/codeintel/autoindex/inference/mock_gitclient_test.go
@@ -160,14 +160,14 @@ type GitClientFileExistsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitClientFileExistsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c GitClientFileExistsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitClientFileExistsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c GitClientFileExistsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // GitClientListFilesFunc describes the behavior when the ListFiles method
@@ -268,14 +268,14 @@ type GitClientListFilesFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitClientListFilesFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c GitClientListFilesFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitClientListFilesFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c GitClientListFilesFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }
 
 // GitClientRawContentsFunc describes the behavior when the RawContents
@@ -377,12 +377,12 @@ type GitClientRawContentsFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c GitClientRawContentsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1}
+func (c GitClientRawContentsFuncCall) Args() []any {
+	return []any{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c GitClientRawContentsFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+func (c GitClientRawContentsFuncCall) Results() []any {
+	return []any{c.Result0, c.Result1}
 }

--- a/lib/codeintel/lsif/conversion/reader.go
+++ b/lib/codeintel/lsif/conversion/reader.go
@@ -35,7 +35,7 @@ func Read(ctx context.Context, r io.Reader) <-chan Pair {
 	return elements
 }
 
-func translatePayload(payload interface{}) interface{} {
+func translatePayload(payload any) any {
 	switch v := payload.(type) {
 	case reader.Edge:
 		return Edge(v)

--- a/lib/codeintel/lsif/protocol/reader/reader.go
+++ b/lib/codeintel/lsif/protocol/reader/reader.go
@@ -45,7 +45,7 @@ func readLines(ctx context.Context, r io.Reader, unmarshal func(line []byte) (El
 	scanner.Buffer(make([]byte, LineBufferSize), LineBufferSize)
 
 	// Pool of buffers used to transfer copies of the scanner slice to unmarshal workers
-	pool := sync.Pool{New: func() interface{} { return new(bytes.Buffer) }}
+	pool := sync.Pool{New: func() any { return new(bytes.Buffer) }}
 
 	// Read the document in a separate go-routine.
 	lineCh := make(chan *bytes.Buffer, ChannelBufferSize)

--- a/lib/codeintel/lsif/protocol/reader/types.go
+++ b/lib/codeintel/lsif/protocol/reader/types.go
@@ -6,7 +6,7 @@ type Element struct {
 	ID      int
 	Type    string
 	Label   string
-	Payload interface{}
+	Payload any
 }
 
 type Edge struct {

--- a/lib/codeintel/lsif/protocol/reader/unmarshal.go
+++ b/lib/codeintel/lsif/protocol/reader/unmarshal.go
@@ -49,7 +49,7 @@ func unmarshalElement(interner *Interner, line []byte) (_ Element, err error) {
 	return element, err
 }
 
-func unmarshalEdge(interner *Interner, line []byte) (interface{}, error) {
+func unmarshalEdge(interner *Interner, line []byte) (any, error) {
 	if edge, ok := unmarshalEdgeFast(line); ok {
 		return edge, nil
 	}
@@ -121,9 +121,9 @@ func unmarshalEdgeFast(line []byte) (Edge, bool) {
 	}, true
 }
 
-var edgeUnmarshalers = map[string]func(line []byte) (interface{}, error){}
+var edgeUnmarshalers = map[string]func(line []byte) (any, error){}
 
-var vertexUnmarshalers = map[string]func(line []byte) (interface{}, error){
+var vertexUnmarshalers = map[string]func(line []byte) (any, error){
 	"metaData":             unmarshalMetaData,
 	"document":             unmarshalDocument,
 	"documentSymbolResult": unmarshalDocumentSymbolResult,
@@ -134,7 +134,7 @@ var vertexUnmarshalers = map[string]func(line []byte) (interface{}, error){
 	"diagnosticResult":     unmarshalDiagnosticResult,
 }
 
-func unmarshalMetaData(line []byte) (interface{}, error) {
+func unmarshalMetaData(line []byte) (any, error) {
 	var payload struct {
 		Version     string `json:"version"`
 		ProjectRoot string `json:"projectRoot"`
@@ -149,7 +149,7 @@ func unmarshalMetaData(line []byte) (interface{}, error) {
 	}, nil
 }
 
-func unmarshalDocumentSymbolResult(line []byte) (interface{}, error) {
+func unmarshalDocumentSymbolResult(line []byte) (any, error) {
 	var payload struct {
 		Result []*protocol.RangeBasedDocumentSymbol `json:"result"`
 	}
@@ -159,7 +159,7 @@ func unmarshalDocumentSymbolResult(line []byte) (interface{}, error) {
 	return payload.Result, nil
 }
 
-func unmarshalDocument(line []byte) (interface{}, error) {
+func unmarshalDocument(line []byte) (any, error) {
 	var payload struct {
 		URI string `json:"uri"`
 	}
@@ -170,7 +170,7 @@ func unmarshalDocument(line []byte) (interface{}, error) {
 	return payload.URI, nil
 }
 
-func unmarshalRange(line []byte) (interface{}, error) {
+func unmarshalRange(line []byte) (any, error) {
 	type _position struct {
 		Line      int `json:"line"`
 		Character int `json:"character"`
@@ -239,7 +239,7 @@ func unmarshalRange(line []byte) (interface{}, error) {
 
 var HoverPartSeparator = "\n\n---\n\n"
 
-func unmarshalHover(line []byte) (interface{}, error) {
+func unmarshalHover(line []byte) (any, error) {
 	type _hoverResult struct {
 		Contents json.RawMessage `json:"contents"`
 	}
@@ -307,7 +307,7 @@ func unmarshalHoverPart(raw json.RawMessage) (*string, error) {
 	return &marked, nil
 }
 
-func unmarshalMoniker(line []byte) (interface{}, error) {
+func unmarshalMoniker(line []byte) (any, error) {
 	var payload struct {
 		Kind       string `json:"kind"`
 		Scheme     string `json:"scheme"`
@@ -328,7 +328,7 @@ func unmarshalMoniker(line []byte) (interface{}, error) {
 	}, nil
 }
 
-func unmarshalPackageInformation(line []byte) (interface{}, error) {
+func unmarshalPackageInformation(line []byte) (any, error) {
 	var payload struct {
 		Name    string `json:"name"`
 		Version string `json:"version"`
@@ -343,7 +343,7 @@ func unmarshalPackageInformation(line []byte) (interface{}, error) {
 	}, nil
 }
 
-func unmarshalDiagnosticResult(line []byte) (interface{}, error) {
+func unmarshalDiagnosticResult(line []byte) (any, error) {
 	type _position struct {
 		Line      int `json:"line"`
 		Character int `json:"character"`

--- a/lib/codeintel/lsif/protocol/reader/unmarshal_documentation.go
+++ b/lib/codeintel/lsif/protocol/reader/unmarshal_documentation.go
@@ -13,7 +13,7 @@ func init() {
 	edgeUnmarshalers[string(protocol.EdgeSourcegraphDocumentationString)] = unmarshalDocumentationStringEdge
 }
 
-func unmarshalDocumentationResult(line []byte) (interface{}, error) {
+func unmarshalDocumentationResult(line []byte) (any, error) {
 	var payload struct {
 		Result protocol.Documentation `json:"result"`
 	}
@@ -23,7 +23,7 @@ func unmarshalDocumentationResult(line []byte) (interface{}, error) {
 	return payload.Result, nil
 }
 
-func unmarshalDocumentationString(line []byte) (interface{}, error) {
+func unmarshalDocumentationString(line []byte) (any, error) {
 	var payload struct {
 		Result protocol.MarkupContent `json:"result"`
 	}
@@ -39,7 +39,7 @@ type DocumentationStringEdge struct {
 	Kind protocol.DocumentationStringKind
 }
 
-func unmarshalDocumentationStringEdge(line []byte) (interface{}, error) {
+func unmarshalDocumentationStringEdge(line []byte) (any, error) {
 	var payload struct {
 		OutV int    `json:"outV"`
 		InV  int    `json:"inV"`

--- a/lib/codeintel/lsif/protocol/reader/unmarshal_test.go
+++ b/lib/codeintel/lsif/protocol/reader/unmarshal_test.go
@@ -164,7 +164,7 @@ func TestUnmarshalRangeWithTag(t *testing.T) {
 	}
 }
 
-var result interface{}
+var result any
 
 func BenchmarkUnmarshalHover(b *testing.B) {
 	for i := 0; i < b.N; i++ {

--- a/lib/codeintel/lsif/protocol/writer/writer.go
+++ b/lib/codeintel/lsif/protocol/writer/writer.go
@@ -14,7 +14,7 @@ var marshaller = jsoniter.ConfigFastest
 // underlying writer as newline-delimited JSON.
 type JSONWriter interface {
 	// Write emits a single vertex or edge value.
-	Write(v interface{})
+	Write(v any)
 
 	// Flush ensures that all elements have been written to the underlying writer.
 	Flush() error
@@ -22,7 +22,7 @@ type JSONWriter interface {
 
 type jsonWriter struct {
 	wg             sync.WaitGroup
-	ch             chan interface{}
+	ch             chan any
 	bufferedWriter *bufio.Writer
 	err            error
 }
@@ -37,7 +37,7 @@ const writerBufferSize = 4096
 
 // NewJSONWriter creates a new JSONWriter wrapping the given writer.
 func NewJSONWriter(w io.Writer) JSONWriter {
-	ch := make(chan interface{}, channelBufferSize)
+	ch := make(chan any, channelBufferSize)
 	bufferedWriter := bufio.NewWriterSize(w, writerBufferSize)
 	jw := &jsonWriter{ch: ch, bufferedWriter: bufferedWriter}
 	encoder := marshaller.NewEncoder(bufferedWriter)
@@ -61,7 +61,7 @@ func NewJSONWriter(w io.Writer) JSONWriter {
 }
 
 // Write emits a single vertex or edge value.
-func (jw *jsonWriter) Write(v interface{}) {
+func (jw *jsonWriter) Write(v any) {
 	jw.ch <- v
 }
 

--- a/lib/codeintel/lsif/reader/errors.go
+++ b/lib/codeintel/lsif/reader/errors.go
@@ -12,7 +12,7 @@ type ValidationError struct {
 }
 
 // NewValidationError creates a new validation error with the given error message.
-func NewValidationError(format string, args ...interface{}) *ValidationError {
+func NewValidationError(format string, args ...any) *ValidationError {
 	return &ValidationError{
 		Message: fmt.Sprintf(format, args...),
 	}

--- a/lib/codeintel/lsif/validation/context.go
+++ b/lib/codeintel/lsif/validation/context.go
@@ -30,7 +30,7 @@ func NewValidationContext() *ValidationContext {
 }
 
 // AddError creates a new validaton error and saves it in the validation context.
-func (ctx *ValidationContext) AddError(message string, args ...interface{}) *reader.ValidationError {
+func (ctx *ValidationContext) AddError(message string, args ...any) *reader.ValidationError {
 	err := reader.NewValidationError(message, args...)
 
 	ctx.ErrorsLock.Lock()

--- a/lib/codeintel/tools/lsif-index-tester/main.go
+++ b/lib/codeintel/tools/lsif-index-tester/main.go
@@ -67,7 +67,7 @@ var debug bool
 // TODO: Do more monitoring of the process.
 // var monitor bool
 
-func logFatal(msg string, args ...interface{}) {
+func logFatal(msg string, args ...any) {
 	log15.Error(msg, args...)
 	os.Exit(1)
 }

--- a/lib/codeintel/tools/lsif-index-tester/proc_profiling.go
+++ b/lib/codeintel/tools/lsif-index-tester/proc_profiling.go
@@ -11,7 +11,7 @@ import (
 // different results.
 // Something to consider for later. That's why the code lives in a separate place though.
 
-func MaxMemoryInKB(usage interface{}) (int64, error) {
+func MaxMemoryInKB(usage any) (int64, error) {
 	sysUsage, ok := usage.(*syscall.Rusage)
 
 	if !ok {

--- a/lib/output/capabilities.go
+++ b/lib/output/capabilities.go
@@ -56,8 +56,8 @@ func detectColor(atty bool) bool {
 	return true
 }
 
-func (c *capabilities) formatArgs(args []interface{}) []interface{} {
-	out := make([]interface{}, len(args))
+func (c *capabilities) formatArgs(args []any) []any {
+	out := make([]any, len(args))
 	for i, arg := range args {
 		if _, ok := arg.(Style); ok && !c.Color {
 			out[i] = ""

--- a/lib/output/line.go
+++ b/lib/output/line.go
@@ -10,7 +10,7 @@ type FancyLine struct {
 	emoji  string
 	style  Style
 	format string
-	args   []interface{}
+	args   []any
 }
 
 // Line creates a new FancyLine without a format string.
@@ -19,13 +19,13 @@ func Line(emoji string, style Style, s string) FancyLine {
 		emoji:  emoji,
 		style:  style,
 		format: "%s",
-		args:   []interface{}{s},
+		args:   []any{s},
 	}
 }
 
 // Line creates a new FancyLine with a format string. As with Writer, the
 // arguments may include Style instances with the %s specifier.
-func Linef(emoji string, style Style, format string, a ...interface{}) FancyLine {
+func Linef(emoji string, style Style, format string, a ...any) FancyLine {
 	return FancyLine{
 		emoji:  emoji,
 		style:  style,
@@ -39,6 +39,6 @@ func (ol FancyLine) write(w io.Writer, caps capabilities) {
 		fmt.Fprint(w, ol.emoji+" ")
 	}
 
-	fmt.Fprintf(w, "%s"+ol.format+"%s", caps.formatArgs(append(append([]interface{}{ol.style}, ol.args...), StyleReset))...)
+	fmt.Fprintf(w, "%s"+ol.format+"%s", caps.formatArgs(append(append([]any{ol.style}, ol.args...), StyleReset))...)
 	_, _ = w.Write([]byte("\n"))
 }

--- a/lib/output/noop_writer.go
+++ b/lib/output/noop_writer.go
@@ -2,9 +2,9 @@ package output
 
 type NoopWriter struct{}
 
-func (NoopWriter) Write(s string)                              {}
-func (NoopWriter) Writef(format string, args ...interface{})   {}
-func (NoopWriter) WriteLine(line FancyLine)                    {}
-func (NoopWriter) Verbose(s string)                            {}
-func (NoopWriter) Verbosef(format string, args ...interface{}) {}
-func (NoopWriter) VerboseLine(line FancyLine)                  {}
+func (NoopWriter) Write(s string)                      {}
+func (NoopWriter) Writef(format string, args ...any)   {}
+func (NoopWriter) WriteLine(line FancyLine)            {}
+func (NoopWriter) Verbose(s string)                    {}
+func (NoopWriter) Verbosef(format string, args ...any) {}
+func (NoopWriter) VerboseLine(line FancyLine)          {}

--- a/lib/output/output.go
+++ b/lib/output/output.go
@@ -18,12 +18,12 @@ import (
 type Writer interface {
 	// These methods only write the given message if verbose mode is enabled.
 	Verbose(s string)
-	Verbosef(format string, args ...interface{})
+	Verbosef(format string, args ...any)
 	VerboseLine(line FancyLine)
 
 	// These methods write their messages unconditionally.
 	Write(s string)
-	Writef(format string, args ...interface{})
+	Writef(format string, args ...any)
 	WriteLine(line FancyLine)
 }
 
@@ -146,7 +146,7 @@ func (o *Output) Verbose(s string) {
 	}
 }
 
-func (o *Output) Verbosef(format string, args ...interface{}) {
+func (o *Output) Verbosef(format string, args ...any) {
 	if o.opts.Verbose {
 		o.Writef(format, args...)
 	}
@@ -164,7 +164,7 @@ func (o *Output) Write(s string) {
 	fmt.Fprintln(o.w, s)
 }
 
-func (o *Output) Writef(format string, args ...interface{}) {
+func (o *Output) Writef(format string, args ...any) {
 	o.Lock()
 	defer o.Unlock()
 	fmt.Fprintf(o.w, format, o.caps.formatArgs(args)...)
@@ -234,5 +234,5 @@ func (o *Output) moveUp(lines int) {
 // writeStyle is a helper to write a style while respecting the terminal
 // capabilities.
 func (o *Output) writeStyle(style Style) {
-	fmt.Fprintf(o.w, "%s", o.caps.formatArgs([]interface{}{style})...)
+	fmt.Fprintf(o.w, "%s", o.caps.formatArgs([]any{style})...)
 }

--- a/lib/output/pending.go
+++ b/lib/output/pending.go
@@ -7,7 +7,7 @@ type Pending interface {
 
 	// Update and Updatef change the message shown after the spinner.
 	Update(s string)
-	Updatef(format string, args ...interface{})
+	Updatef(format string, args ...any)
 
 	// Complete stops the spinner and replaces the pending line with the given
 	// message.

--- a/lib/output/pending_simple.go
+++ b/lib/output/pending_simple.go
@@ -8,7 +8,7 @@ func (p *pendingSimple) Update(s string) {
 	p.Write(s + "...")
 }
 
-func (p *pendingSimple) Updatef(format string, args ...interface{}) {
+func (p *pendingSimple) Updatef(format string, args ...any) {
 	p.Writef(format+"...", args...)
 }
 

--- a/lib/output/pending_tty.go
+++ b/lib/output/pending_tty.go
@@ -20,7 +20,7 @@ func (p *pendingTTY) Verbose(s string) {
 	}
 }
 
-func (p *pendingTTY) Verbosef(format string, args ...interface{}) {
+func (p *pendingTTY) Verbosef(format string, args ...any) {
 	if p.o.opts.Verbose {
 		p.Writef(format, args...)
 	}
@@ -42,7 +42,7 @@ func (p *pendingTTY) Write(s string) {
 	p.write(p.line)
 }
 
-func (p *pendingTTY) Writef(format string, args ...interface{}) {
+func (p *pendingTTY) Writef(format string, args ...any) {
 	p.o.Lock()
 	defer p.o.Unlock()
 
@@ -68,14 +68,14 @@ func (p *pendingTTY) Update(s string) {
 	defer p.o.Unlock()
 
 	p.line.format = "%s"
-	p.line.args = []interface{}{s}
+	p.line.args = []any{s}
 
 	p.o.moveUp(1)
 	p.o.clearCurrentLine()
 	p.write(p.line)
 }
 
-func (p *pendingTTY) Updatef(format string, args ...interface{}) {
+func (p *pendingTTY) Updatef(format string, args ...any) {
 	p.o.Lock()
 	defer p.o.Unlock()
 
@@ -141,7 +141,7 @@ func (p *pendingTTY) updateEmoji(emoji string) {
 	// We add an extra space because the Braille characters are single width,
 	// but emoji are generally double width and that's what will most likely be
 	// used in the completion message, if any.
-	p.line.emoji = fmt.Sprintf("%s%s ", p.o.caps.formatArgs([]interface{}{
+	p.line.emoji = fmt.Sprintf("%s%s ", p.o.caps.formatArgs([]any{
 		p.line.style,
 		emoji,
 	})...)

--- a/lib/output/progress_tty.go
+++ b/lib/output/progress_tty.go
@@ -90,7 +90,7 @@ func (p *progressTTY) Verbose(s string) {
 	}
 }
 
-func (p *progressTTY) Verbosef(format string, args ...interface{}) {
+func (p *progressTTY) Verbosef(format string, args ...any) {
 	if p.o.opts.Verbose {
 		p.Writef(format, args...)
 	}
@@ -112,7 +112,7 @@ func (p *progressTTY) Write(s string) {
 	p.draw()
 }
 
-func (p *progressTTY) Writef(format string, args ...interface{}) {
+func (p *progressTTY) Writef(format string, args ...any) {
 	p.o.Lock()
 	defer p.o.Unlock()
 

--- a/lib/output/progress_with_status_bars.go
+++ b/lib/output/progress_with_status_bars.go
@@ -3,10 +3,10 @@ package output
 type ProgressWithStatusBars interface {
 	Progress
 
-	StatusBarUpdatef(i int, format string, args ...interface{})
-	StatusBarCompletef(i int, format string, args ...interface{})
-	StatusBarFailf(i int, format string, args ...interface{})
-	StatusBarResetf(i int, label, format string, args ...interface{})
+	StatusBarUpdatef(i int, format string, args ...any)
+	StatusBarCompletef(i int, format string, args ...any)
+	StatusBarFailf(i int, format string, args ...any)
+	StatusBarResetf(i int, label, format string, args ...any)
 }
 
 func newProgressWithStatusBars(bars []ProgressBar, statusBars []*StatusBar, o *Output, opts *ProgressOpts) ProgressWithStatusBars {

--- a/lib/output/progress_with_status_bars_simple.go
+++ b/lib/output/progress_with_status_bars_simple.go
@@ -16,13 +16,13 @@ func (p *progressWithStatusBarsSimple) Complete() {
 	writeStatusBars(p.Output, p.statusBars)
 }
 
-func (p *progressWithStatusBarsSimple) StatusBarUpdatef(i int, format string, args ...interface{}) {
+func (p *progressWithStatusBarsSimple) StatusBarUpdatef(i int, format string, args ...any) {
 	if p.statusBars[i] != nil {
 		p.statusBars[i].Updatef(format, args...)
 	}
 }
 
-func (p *progressWithStatusBarsSimple) StatusBarCompletef(i int, format string, args ...interface{}) {
+func (p *progressWithStatusBarsSimple) StatusBarCompletef(i int, format string, args ...any) {
 	if p.statusBars[i] != nil {
 		wasComplete := p.statusBars[i].completed
 		p.statusBars[i].Completef(format, args...)
@@ -32,7 +32,7 @@ func (p *progressWithStatusBarsSimple) StatusBarCompletef(i int, format string, 
 	}
 }
 
-func (p *progressWithStatusBarsSimple) StatusBarFailf(i int, format string, args ...interface{}) {
+func (p *progressWithStatusBarsSimple) StatusBarFailf(i int, format string, args ...any) {
 	if p.statusBars[i] != nil {
 		wasCompleted := p.statusBars[i].completed
 		p.statusBars[i].Failf(format, args...)
@@ -42,7 +42,7 @@ func (p *progressWithStatusBarsSimple) StatusBarFailf(i int, format string, args
 	}
 }
 
-func (p *progressWithStatusBarsSimple) StatusBarResetf(i int, label, format string, args ...interface{}) {
+func (p *progressWithStatusBarsSimple) StatusBarResetf(i int, label, format string, args ...any) {
 	if p.statusBars[i] != nil {
 		p.statusBars[i].Resetf(label, format, args...)
 	}
@@ -89,7 +89,7 @@ func newProgressWithStatusBarsSimple(bars []*ProgressBar, statusBars []*StatusBa
 }
 
 func writeStatusBar(w Writer, bar *StatusBar) {
-	w.Writef("%s: "+bar.format, append([]interface{}{bar.label}, bar.args...)...)
+	w.Writef("%s: "+bar.format, append([]any{bar.label}, bar.args...)...)
 }
 
 func writeStatusBars(o *Output, bars []*StatusBar) {

--- a/lib/output/progress_with_status_bars_tty.go
+++ b/lib/output/progress_with_status_bars_tty.go
@@ -123,7 +123,7 @@ func (p *progressWithStatusBarsTTY) SetValue(i int, v float64) {
 	p.drawInSitu()
 }
 
-func (p *progressWithStatusBarsTTY) StatusBarResetf(i int, label, format string, args ...interface{}) {
+func (p *progressWithStatusBarsTTY) StatusBarResetf(i int, label, format string, args ...any) {
 	p.o.Lock()
 	defer p.o.Unlock()
 
@@ -135,7 +135,7 @@ func (p *progressWithStatusBarsTTY) StatusBarResetf(i int, label, format string,
 	p.drawInSitu()
 }
 
-func (p *progressWithStatusBarsTTY) StatusBarUpdatef(i int, format string, args ...interface{}) {
+func (p *progressWithStatusBarsTTY) StatusBarUpdatef(i int, format string, args ...any) {
 	p.o.Lock()
 	defer p.o.Unlock()
 
@@ -146,7 +146,7 @@ func (p *progressWithStatusBarsTTY) StatusBarUpdatef(i int, format string, args 
 	p.drawInSitu()
 }
 
-func (p *progressWithStatusBarsTTY) StatusBarCompletef(i int, format string, args ...interface{}) {
+func (p *progressWithStatusBarsTTY) StatusBarCompletef(i int, format string, args ...any) {
 	p.o.Lock()
 	defer p.o.Unlock()
 
@@ -157,7 +157,7 @@ func (p *progressWithStatusBarsTTY) StatusBarCompletef(i int, format string, arg
 	p.drawInSitu()
 }
 
-func (p *progressWithStatusBarsTTY) StatusBarFailf(i int, format string, args ...interface{}) {
+func (p *progressWithStatusBarsTTY) StatusBarFailf(i int, format string, args ...any) {
 	p.o.Lock()
 	defer p.o.Unlock()
 
@@ -260,7 +260,7 @@ func (p *progressWithStatusBarsTTY) Verbose(s string) {
 	}
 }
 
-func (p *progressWithStatusBarsTTY) Verbosef(format string, args ...interface{}) {
+func (p *progressWithStatusBarsTTY) Verbosef(format string, args ...any) {
 	if p.o.opts.Verbose {
 		p.Writef(format, args...)
 	}
@@ -282,7 +282,7 @@ func (p *progressWithStatusBarsTTY) Write(s string) {
 	p.draw()
 }
 
-func (p *progressWithStatusBarsTTY) Writef(format string, args ...interface{}) {
+func (p *progressWithStatusBarsTTY) Writef(format string, args ...any) {
 	p.o.Lock()
 	defer p.o.Unlock()
 

--- a/lib/output/status_bar.go
+++ b/lib/output/status_bar.go
@@ -10,7 +10,7 @@ type StatusBar struct {
 
 	label  string
 	format string
-	args   []interface{}
+	args   []any
 
 	initialized bool
 	startedAt   time.Time
@@ -18,7 +18,7 @@ type StatusBar struct {
 }
 
 // Completef sets the StatusBar to completed and updates its text.
-func (sb *StatusBar) Completef(format string, args ...interface{}) {
+func (sb *StatusBar) Completef(format string, args ...any) {
 	sb.completed = true
 	sb.format = format
 	sb.args = args
@@ -26,13 +26,13 @@ func (sb *StatusBar) Completef(format string, args ...interface{}) {
 }
 
 // Failf sets the StatusBar to completed and failed and updates its text.
-func (sb *StatusBar) Failf(format string, args ...interface{}) {
+func (sb *StatusBar) Failf(format string, args ...any) {
 	sb.Completef(format, args...)
 	sb.failed = true
 }
 
 // Resetf sets the status of the StatusBar to incomplete and updates its label and text.
-func (sb *StatusBar) Resetf(label, format string, args ...interface{}) {
+func (sb *StatusBar) Resetf(label, format string, args ...any) {
 	sb.initialized = true
 	sb.completed = false
 	sb.failed = false
@@ -44,7 +44,7 @@ func (sb *StatusBar) Resetf(label, format string, args ...interface{}) {
 }
 
 // Updatef updates the StatusBar's text.
-func (sb *StatusBar) Updatef(format string, args ...interface{}) {
+func (sb *StatusBar) Updatef(format string, args ...any) {
 	sb.initialized = true
 	sb.format = format
 	sb.args = args

--- a/schema/extension_schema.go
+++ b/schema/extension_schema.go
@@ -7,15 +7,15 @@ import "github.com/sourcegraph/go-jsonschema/jsonschema"
 
 // SourcegraphExtensionManifest description: The Sourcegraph extension manifest describes the extension and the features it provides.
 type SourcegraphExtensionManifest struct {
-	ActivationEvents []string                `json:"activationEvents"`
-	Args             *map[string]interface{} `json:"args,omitempty"`
-	Contributes      *Contributions          `json:"contributes,omitempty"`
-	Description      string                  `json:"description,omitempty"`
-	Icon             string                  `json:"icon,omitempty"`
-	Readme           string                  `json:"readme,omitempty"`
-	Repository       *ExtensionRepository    `json:"repository,omitempty"`
-	Wip              bool                    `json:"wip,omitempty"`
-	Url              string                  `json:"url"`
+	ActivationEvents []string             `json:"activationEvents"`
+	Args             *map[string]any      `json:"args,omitempty"`
+	Contributes      *Contributions       `json:"contributes,omitempty"`
+	Description      string               `json:"description,omitempty"`
+	Icon             string               `json:"icon,omitempty"`
+	Readme           string               `json:"readme,omitempty"`
+	Repository       *ExtensionRepository `json:"repository,omitempty"`
+	Wip              bool                 `json:"wip,omitempty"`
+	Url              string               `json:"url"`
 }
 
 // ExtensionRepository description: The location of the version control repository for this extension.
@@ -25,13 +25,13 @@ type ExtensionRepository struct {
 }
 
 type Action struct {
-	ActionItem       *ActionItem   `json:"actionItem,omitempty"`
-	Category         string        `json:"category,omitempty"`
-	Command          string        `json:"command,omitempty"`
-	CommandArguments []interface{} `json:"commandArguments,omitempty"`
-	IconURL          string        `json:"iconURL,omitempty"`
-	Id               string        `json:"id,omitempty"`
-	Title            string        `json:"title,omitempty"`
+	ActionItem       *ActionItem `json:"actionItem,omitempty"`
+	Category         string      `json:"category,omitempty"`
+	Command          string      `json:"command,omitempty"`
+	CommandArguments []any       `json:"commandArguments,omitempty"`
+	IconURL          string      `json:"iconURL,omitempty"`
+	Id               string      `json:"id,omitempty"`
+	Title            string      `json:"title,omitempty"`
 }
 
 // ActionItem description: The action item.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -143,7 +143,7 @@ type BatchChangeRolloutWindow struct {
 	// End description: Window end time. If omitted, no time window is applied to the day(s) that match this rule.
 	End string `json:"end,omitempty"`
 	// Rate description: The rate changesets will be published at.
-	Rate interface{} `json:"rate"`
+	Rate any `json:"rate"`
 	// Start description: Window start time. If omitted, no time window is applied to the day(s) that match this rule.
 	Start string `json:"start,omitempty"`
 }
@@ -159,7 +159,7 @@ type BatchSpec struct {
 	// Name description: The name of the batch change, which is unique among all batch changes in the namespace. A batch change's name is case-preserving.
 	Name string `json:"name"`
 	// On description: The set of repositories (and branches) to run the batch change on, specified as a list of search queries (that match repositories) and/or specific repositories.
-	On []interface{} `json:"on,omitempty"`
+	On []any `json:"on,omitempty"`
 	// Steps description: The sequence of commands to run (for each repository branch matched in the `on` property) to produce the workspace changes that will be included in the batch change.
 	Steps []*Step `json:"steps,omitempty"`
 	// TransformChanges description: Optional transformations to apply to the changes produced in each repository.
@@ -369,7 +369,7 @@ type ChangesetTemplate struct {
 	// Commit description: The Git commit to create with the changes.
 	Commit ExpandedGitCommitDescription `json:"commit"`
 	// Published description: Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the batch change, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host. If omitted, the publication state is controlled from the Batch Changes UI.
-	Published interface{} `json:"published,omitempty"`
+	Published any `json:"published,omitempty"`
 	// Title description: The title of the changeset.
 	Title string `json:"title"`
 }
@@ -562,7 +562,7 @@ type Extensions struct {
 	// Disabled description: Disable all usage of extensions.
 	Disabled *bool `json:"disabled,omitempty"`
 	// RemoteRegistry description: The remote extension registry URL, or `false` to not use a remote extension registry. If not set, the default remote extension registry URL is used.
-	RemoteRegistry interface{} `json:"remoteRegistry,omitempty"`
+	RemoteRegistry any `json:"remoteRegistry,omitempty"`
 }
 type ExternalIdentity struct {
 	// AuthProviderID description: The value of the `configID` field of the targeted authentication provider.
@@ -843,7 +843,7 @@ func (v *IdentityProvider) UnmarshalJSON(data []byte) error {
 
 type ImportChangesets struct {
 	// ExternalIDs description: The changesets to import from the code host. For GitHub this is the PR number, for GitLab this is the MR number, for Bitbucket Server this is the PR number.
-	ExternalIDs []interface{} `json:"externalIDs"`
+	ExternalIDs []any `json:"externalIDs"`
 	// Repository description: The repository name as configured on your Sourcegraph instance.
 	Repository string `json:"repository"`
 }
@@ -868,7 +868,7 @@ type InsightSeries struct {
 	// Label description: The label to use for the series in the graph.
 	Label string `json:"label"`
 	// RepositoriesList description: Performs a search query and shows the number of results returned.
-	RepositoriesList []interface{} `json:"repositoriesList,omitempty"`
+	RepositoriesList []any `json:"repositoriesList,omitempty"`
 	// Search description: Performs a search query and shows the number of results returned.
 	Search string `json:"search,omitempty"`
 	// Webhook description: (not yet supported) Fetch data from a webhook URL.
@@ -1101,7 +1101,7 @@ type Overrides struct {
 	// Key description: The key that we want to override for example a username
 	Key string `json:"key,omitempty"`
 	// Limit description: The limit per hour, 'unlimited' or 'blocked'
-	Limit interface{} `json:"limit,omitempty"`
+	Limit any `json:"limit,omitempty"`
 }
 
 // ParentSourcegraph description: URL to fetch unreachable repository details from. Defaults to "https://sourcegraph.com"
@@ -1343,7 +1343,7 @@ type Settings struct {
 	// SearchMigrateParser description: REMOVED. Previously, a flag to enable and/or-expressions in queries as an aid transition to new language features in versions <= 3.24.0.
 	SearchMigrateParser *bool `json:"search.migrateParser,omitempty"`
 	// SearchRepositoryGroups description: Named groups of repositories that can be referenced in a search query using the `repogroup:` operator. The list can contain string literals (to include single repositories) and JSON objects with a "regex" field (to include all repositories matching the regular expression). Retrieving repogroups via the GQL interface will currently exclude repositories matched by regex patterns. #14208.
-	SearchRepositoryGroups map[string][]interface{} `json:"search.repositoryGroups,omitempty"`
+	SearchRepositoryGroups map[string][]any `json:"search.repositoryGroups,omitempty"`
 	// SearchSavedQueries description: DEPRECATED: Saved search queries
 	SearchSavedQueries []*SearchSavedQueries `json:"search.savedQueries,omitempty"`
 	// SearchScopes description: Predefined search snippets that can be appended to any search (also known as search scopes)
@@ -1567,11 +1567,11 @@ type Step struct {
 	// Container description: The Docker image used to launch the Docker container in which the shell command is run.
 	Container string `json:"container"`
 	// Env description: Environment variables to set in the step environment.
-	Env interface{} `json:"env,omitempty"`
+	Env any `json:"env,omitempty"`
 	// Files description: Files that should be mounted into or be created inside the Docker container.
 	Files map[string]string `json:"files,omitempty"`
 	// If description: A condition to check before executing steps. Supports templating. The value 'true' is interpreted as true.
-	If interface{} `json:"if,omitempty"`
+	If any `json:"if,omitempty"`
 	// Outputs description: Output variables of this step that can be referenced in the changesetTemplate or other steps via outputs.<name-of-output>
 	Outputs map[string]AdditionalProperties `json:"outputs,omitempty"`
 	// Run description: The shell command to run in the container. It can also be a multi-line shell script. The working directory is the root directory of the repository checkout.
@@ -1590,7 +1590,7 @@ type TlsExternal struct {
 // TransformChanges description: Optional transformations to apply to the changes produced in each repository.
 type TransformChanges struct {
 	// Group description: A list of groups of changes in a repository that each create a separate, additional changeset for this repository, with all ungrouped changes being in the default changeset.
-	Group []interface{} `json:"group,omitempty"`
+	Group []any `json:"group,omitempty"`
 }
 type UpdateIntervalRule struct {
 	// Interval description: An integer representing the number of minutes to wait until the next update


### PR DESCRIPTION
Rewrites `interface{}` to `any` using `gofmt`

[_Created by Sourcegraph batch change `christine/Go-upgrade-type`._](https://demo.sourcegraph.com/users/christine/batch-changes/Go-upgrade-type)